### PR TITLE
Add multiple images and admin ordering for artworks

### DIFF
--- a/drizzle/0007_glossy_microchip.sql
+++ b/drizzle/0007_glossy_microchip.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `artworks` ADD `home_page_order` integer;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,986 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "90d49f5d-88cb-48ee-afc3-d2437c42e941",
+  "prevId": "78ec09e9-e41a-45fc-b431-dc62574ad68f",
+  "tables": {
+    "artworks": {
+      "name": "artworks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dimension_unit": {
+          "name": "dimension_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'in'"
+        },
+        "default_image_url": {
+          "name": "default_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "images_json": {
+          "name": "images_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "home_page_order": {
+          "name": "home_page_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artworks_slug_unique": {
+          "name": "artworks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "artworks_slug_idx": {
+          "name": "artworks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artworks_to_collections": {
+      "name": "artworks_to_collections",
+      "columns": {
+        "artwork_id": {
+          "name": "artwork_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default_for_collection": {
+          "name": "is_default_for_collection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artwork_collection_one_default_per_collection": {
+          "name": "artwork_collection_one_default_per_collection",
+          "columns": [
+            "collection_id"
+          ],
+          "isUnique": true,
+          "where": "\"artworks_to_collections\".\"is_default_for_collection\" = 1"
+        }
+      },
+      "foreignKeys": {
+        "artworks_to_collections_artwork_id_artworks_id_fk": {
+          "name": "artworks_to_collections_artwork_id_artworks_id_fk",
+          "tableFrom": "artworks_to_collections",
+          "tableTo": "artworks",
+          "columnsFrom": [
+            "artwork_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artworks_to_collections_collection_id_collections_id_fk": {
+          "name": "artworks_to_collections_collection_id_collections_id_fk",
+          "tableFrom": "artworks_to_collections",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artworks_to_collections_artwork_id_collection_id_pk": {
+          "columns": [
+            "artwork_id",
+            "collection_id"
+          ],
+          "name": "artworks_to_collections_artwork_id_collection_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artworks_to_facets": {
+      "name": "artworks_to_facets",
+      "columns": {
+        "artwork_id": {
+          "name": "artwork_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "facet_id": {
+          "name": "facet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artworks_to_facets_facet_idx": {
+          "name": "artworks_to_facets_facet_idx",
+          "columns": [
+            "facet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "artworks_to_facets_artwork_id_artworks_id_fk": {
+          "name": "artworks_to_facets_artwork_id_artworks_id_fk",
+          "tableFrom": "artworks_to_facets",
+          "tableTo": "artworks",
+          "columnsFrom": [
+            "artwork_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artworks_to_facets_facet_id_facets_id_fk": {
+          "name": "artworks_to_facets_facet_id_facets_id_fk",
+          "tableFrom": "artworks_to_facets",
+          "tableTo": "facets",
+          "columnsFrom": [
+            "facet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artworks_to_facets_artwork_id_facet_id_pk": {
+          "columns": [
+            "artwork_id",
+            "facet_id"
+          ],
+          "name": "artworks_to_facets_artwork_id_facet_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "collections": {
+      "name": "collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "collections_slug_unique": {
+          "name": "collections_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "collections_slug_idx": {
+          "name": "collections_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "facets": {
+      "name": "facets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "facets_slug_type_unique": {
+          "name": "facets_slug_type_unique",
+          "columns": [
+            "slug",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "facets_type_idx": {
+          "name": "facets_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork_id": {
+          "name": "artwork_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listed_at": {
+          "name": "listed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sold_at": {
+          "name": "sold_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "products_slug_idx": {
+          "name": "products_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "products_type_idx": {
+          "name": "products_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "products_artwork_idx": {
+          "name": "products_artwork_idx",
+          "columns": [
+            "artwork_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "products_artwork_id_artworks_id_fk": {
+          "name": "products_artwork_id_artworks_id_fk",
+          "tableFrom": "products",
+          "tableTo": "artworks",
+          "columnsFrom": [
+            "artwork_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authenticator": {
+      "name": "authenticator",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticator_userId_credentialID_pk": {
+          "columns": [
+            "userId",
+            "credentialID"
+          ],
+          "name": "authenticator_userId_credentialID_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin": {
+          "name": "admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1765317149423,
       "tag": "0006_whole_micromacro",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1766795748198,
+      "tag": "0007_glossy_microchip",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/admin/home.ts
+++ b/src/actions/admin/home.ts
@@ -1,0 +1,160 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq, isNotNull, asc } from "drizzle-orm";
+import { db, artworks } from "@/database";
+import { guardAdmin } from "@/lib/actions";
+
+export interface HomePageArtwork {
+  id: number;
+  title: string;
+  slug: string;
+  defaultImageUrl: string | null;
+  homePageOrder: number | null;
+}
+
+/**
+ * Get all artworks that are set to appear on the home page (have a homePageOrder)
+ */
+export async function getHomePageArtworksAdmin() {
+  const authError = await guardAdmin();
+  if (authError) return { error: authError.error };
+
+  try {
+    const results = await db
+      .select({
+        id: artworks.id,
+        title: artworks.title,
+        slug: artworks.slug,
+        defaultImageUrl: artworks.defaultImageUrl,
+        homePageOrder: artworks.homePageOrder,
+      })
+      .from(artworks)
+      .where(isNotNull(artworks.homePageOrder))
+      .orderBy(asc(artworks.homePageOrder));
+
+    return { data: results };
+  } catch (error) {
+    console.error("Error fetching home page artworks:", error);
+    return { error: "Failed to fetch home page artworks" };
+  }
+}
+
+/**
+ * Get all published artworks that could be added to the home page
+ */
+export async function getAvailableArtworksForHomeAdmin() {
+  const authError = await guardAdmin();
+  if (authError) return { error: authError.error };
+
+  try {
+    const results = await db
+      .select({
+        id: artworks.id,
+        title: artworks.title,
+        slug: artworks.slug,
+        defaultImageUrl: artworks.defaultImageUrl,
+        homePageOrder: artworks.homePageOrder,
+      })
+      .from(artworks)
+      .where(isNotNull(artworks.publishedAt));
+
+    return { data: results };
+  } catch (error) {
+    console.error("Error fetching available artworks:", error);
+    return { error: "Failed to fetch available artworks" };
+  }
+}
+
+/**
+ * Update the home page order for multiple artworks
+ * Pass an array of artwork IDs in the desired order
+ * Artworks not in the array will have their homePageOrder set to null
+ */
+export async function updateHomePageOrderAdmin(artworkIds: number[]) {
+  const authError = await guardAdmin();
+  if (authError) return authError;
+
+  try {
+    // First, clear all homePageOrder values
+    await db
+      .update(artworks)
+      .set({ homePageOrder: null, updatedAt: new Date() })
+      .where(isNotNull(artworks.homePageOrder));
+
+    // Then set the new order for selected artworks
+    for (let i = 0; i < artworkIds.length; i++) {
+      await db
+        .update(artworks)
+        .set({ homePageOrder: i + 1, updatedAt: new Date() })
+        .where(eq(artworks.id, artworkIds[i]));
+    }
+
+    revalidatePath("/admin/home");
+    revalidatePath("/");
+    return { success: true };
+  } catch (error) {
+    console.error("Error updating home page order:", error);
+    return { success: false, error: "Failed to update home page order" };
+  }
+}
+
+/**
+ * Add an artwork to the home page (at the end of the list)
+ */
+export async function addArtworkToHomePageAdmin(artworkId: number) {
+  const authError = await guardAdmin();
+  if (authError) return authError;
+
+  try {
+    // Get the current maximum order
+    const existing = await db
+      .select({ homePageOrder: artworks.homePageOrder })
+      .from(artworks)
+      .where(isNotNull(artworks.homePageOrder))
+      .orderBy(asc(artworks.homePageOrder));
+
+    const maxOrder =
+      existing.length > 0
+        ? Math.max(...existing.map((a) => a.homePageOrder ?? 0))
+        : 0;
+
+    // Add the artwork with the next order
+    await db
+      .update(artworks)
+      .set({ homePageOrder: maxOrder + 1, updatedAt: new Date() })
+      .where(eq(artworks.id, artworkId));
+
+    revalidatePath("/admin/home");
+    revalidatePath("/");
+    return { success: true };
+  } catch (error) {
+    console.error("Error adding artwork to home page:", error);
+    return { success: false, error: "Failed to add artwork to home page" };
+  }
+}
+
+/**
+ * Remove an artwork from the home page
+ */
+export async function removeArtworkFromHomePageAdmin(artworkId: number) {
+  const authError = await guardAdmin();
+  if (authError) return authError;
+
+  try {
+    await db
+      .update(artworks)
+      .set({ homePageOrder: null, updatedAt: new Date() })
+      .where(eq(artworks.id, artworkId));
+
+    revalidatePath("/admin/home");
+    revalidatePath("/");
+    return { success: true };
+  } catch (error) {
+    console.error("Error removing artwork from home page:", error);
+    return {
+      success: false,
+      error: "Failed to remove artwork from home page",
+    };
+  }
+}

--- a/src/actions/home.ts
+++ b/src/actions/home.ts
@@ -1,17 +1,28 @@
-'use server';
+"use server";
 
-import { findArtworksWithCollections } from '@/models/artwork';
-import type { ArtworkWithCollections } from '@/models/artwork';
+import { findArtworksWithCollections } from "@/models/artwork";
+import type { ArtworkWithCollections } from "@/models/artwork";
 
 export interface HomePageData {
   slides: ArtworkWithCollections[];
 }
 
 export async function getHomePageData(): Promise<HomePageData> {
-  const slides = await findArtworksWithCollections({
+  // First, try to get artworks with explicit home page ordering
+  let slides = await findArtworksWithCollections({
     published: true,
-    isDefaultForCollection: true,
+    onHomePage: true,
+    orderByHomePageOrder: true,
   });
+
+  // Fallback: if no artworks have homePageOrder set, use the old behavior
+  // (artworks marked as default for their collection)
+  if (slides.length === 0) {
+    slides = await findArtworksWithCollections({
+      published: true,
+      isDefaultForCollection: true,
+    });
+  }
 
   return { slides };
 }

--- a/src/app/admin/home/HomePageOrderManager.tsx
+++ b/src/app/admin/home/HomePageOrderManager.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  updateHomePageOrderAdmin,
+  addArtworkToHomePageAdmin,
+  removeArtworkFromHomePageAdmin,
+  type HomePageArtwork,
+} from "@/actions/admin/home";
+
+interface HomePageOrderManagerProps {
+  initialHomeArtworks: HomePageArtwork[];
+  availableArtworks: HomePageArtwork[];
+}
+
+export default function HomePageOrderManager({
+  initialHomeArtworks,
+  availableArtworks,
+}: HomePageOrderManagerProps) {
+  const router = useRouter();
+  const [homeArtworks, setHomeArtworks] =
+    useState<HomePageArtwork[]>(initialHomeArtworks);
+  const [available, setAvailable] =
+    useState<HomePageArtwork[]>(availableArtworks);
+  const [isSaving, setIsSaving] = useState(false);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  const handleDragStart = (index: number) => {
+    setDraggedIndex(index);
+  };
+
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    setDragOverIndex(index);
+  };
+
+  const handleDragEnd = () => {
+    if (
+      draggedIndex !== null &&
+      dragOverIndex !== null &&
+      draggedIndex !== dragOverIndex
+    ) {
+      const newArtworks = [...homeArtworks];
+      const [removed] = newArtworks.splice(draggedIndex, 1);
+      newArtworks.splice(dragOverIndex, 0, removed);
+      setHomeArtworks(newArtworks);
+      setHasChanges(true);
+    }
+    setDraggedIndex(null);
+    setDragOverIndex(null);
+  };
+
+  const handleMoveUp = (index: number) => {
+    if (index === 0) return;
+    const newArtworks = [...homeArtworks];
+    [newArtworks[index - 1], newArtworks[index]] = [
+      newArtworks[index],
+      newArtworks[index - 1],
+    ];
+    setHomeArtworks(newArtworks);
+    setHasChanges(true);
+  };
+
+  const handleMoveDown = (index: number) => {
+    if (index === homeArtworks.length - 1) return;
+    const newArtworks = [...homeArtworks];
+    [newArtworks[index], newArtworks[index + 1]] = [
+      newArtworks[index + 1],
+      newArtworks[index],
+    ];
+    setHomeArtworks(newArtworks);
+    setHasChanges(true);
+  };
+
+  const handleRemove = async (artwork: HomePageArtwork) => {
+    setIsSaving(true);
+    const result = await removeArtworkFromHomePageAdmin(artwork.id);
+    if (result.success) {
+      setHomeArtworks(homeArtworks.filter((a) => a.id !== artwork.id));
+      setAvailable([...available, artwork]);
+    }
+    setIsSaving(false);
+    router.refresh();
+  };
+
+  const handleAdd = async (artwork: HomePageArtwork) => {
+    setIsSaving(true);
+    const result = await addArtworkToHomePageAdmin(artwork.id);
+    if (result.success) {
+      setAvailable(available.filter((a) => a.id !== artwork.id));
+      setHomeArtworks([...homeArtworks, artwork]);
+    }
+    setIsSaving(false);
+    router.refresh();
+  };
+
+  const handleSaveOrder = async () => {
+    setIsSaving(true);
+    const artworkIds = homeArtworks.map((a) => a.id);
+    const result = await updateHomePageOrderAdmin(artworkIds);
+    if (result.success) {
+      setHasChanges(false);
+    }
+    setIsSaving(false);
+    router.refresh();
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* Current Home Page Artworks */}
+      <div className="bg-surface border border-outline rounded-lg p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-on-surface">
+            Home Page Carousel ({homeArtworks.length} artwork
+            {homeArtworks.length !== 1 ? "s" : ""})
+          </h2>
+          {hasChanges && (
+            <button
+              onClick={handleSaveOrder}
+              disabled={isSaving}
+              className="px-4 py-2 bg-primary text-on-primary rounded-md hover:opacity-90 disabled:opacity-50 font-medium"
+            >
+              {isSaving ? "Saving..." : "Save Order"}
+            </button>
+          )}
+        </div>
+
+        {homeArtworks.length === 0 ? (
+          <p className="text-on-surface-variant py-8 text-center">
+            No artworks on the home page. Add artworks from below.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {homeArtworks.map((artwork, index) => (
+              <div
+                key={artwork.id}
+                draggable
+                onDragStart={() => handleDragStart(index)}
+                onDragOver={(e) => handleDragOver(e, index)}
+                onDragEnd={handleDragEnd}
+                className={`flex items-center gap-4 p-3 bg-surface-variant/30 border border-outline/50 rounded-lg cursor-move ${
+                  dragOverIndex === index ? "ring-2 ring-primary" : ""
+                } ${draggedIndex === index ? "opacity-50" : ""}`}
+              >
+                {/* Order number */}
+                <div className="w-8 h-8 flex items-center justify-center bg-primary text-on-primary rounded-full font-bold text-sm">
+                  {index + 1}
+                </div>
+
+                {/* Thumbnail */}
+                <div className="w-16 h-16 relative rounded overflow-hidden flex-shrink-0">
+                  {artwork.defaultImageUrl ? (
+                    <Image
+                      src={artwork.defaultImageUrl}
+                      alt={artwork.title}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                  ) : (
+                    <div className="w-full h-full bg-surface-variant flex items-center justify-center text-on-surface-variant text-xs">
+                      No image
+                    </div>
+                  )}
+                </div>
+
+                {/* Title and link */}
+                <div className="flex-1 min-w-0">
+                  <Link
+                    href={`/admin/artworks/${artwork.slug}`}
+                    className="text-on-surface font-medium hover:text-primary truncate block"
+                  >
+                    {artwork.title}
+                  </Link>
+                  <Link
+                    href={`/artworks/${artwork.slug}`}
+                    className="text-sm text-on-surface-variant hover:text-primary"
+                    target="_blank"
+                  >
+                    View on site →
+                  </Link>
+                </div>
+
+                {/* Controls */}
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => handleMoveUp(index)}
+                    disabled={index === 0 || isSaving}
+                    className="p-2 hover:bg-surface-variant rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="Move up"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M5 15l7-7 7 7"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleMoveDown(index)}
+                    disabled={index === homeArtworks.length - 1 || isSaving}
+                    className="p-2 hover:bg-surface-variant rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="Move down"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M19 9l-7 7-7-7"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(artwork)}
+                    disabled={isSaving}
+                    className="p-2 text-red-600 hover:bg-red-50 rounded disabled:opacity-50"
+                    title="Remove from home page"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Available Artworks */}
+      <div className="bg-surface border border-outline rounded-lg p-6">
+        <h2 className="text-lg font-semibold text-on-surface mb-4">
+          Available Artworks ({available.length})
+        </h2>
+
+        {available.length === 0 ? (
+          <p className="text-on-surface-variant py-8 text-center">
+            All published artworks are already on the home page.
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+            {available.map((artwork) => (
+              <div
+                key={artwork.id}
+                className="bg-surface-variant/30 border border-outline/50 rounded-lg overflow-hidden group"
+              >
+                <div className="aspect-square relative">
+                  {artwork.defaultImageUrl ? (
+                    <Image
+                      src={artwork.defaultImageUrl}
+                      alt={artwork.title}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                  ) : (
+                    <div className="w-full h-full bg-surface-variant flex items-center justify-center text-on-surface-variant text-xs">
+                      No image
+                    </div>
+                  )}
+                  <button
+                    onClick={() => handleAdd(artwork)}
+                    disabled={isSaving}
+                    className="absolute inset-0 bg-primary/80 text-on-primary opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center font-medium disabled:opacity-50"
+                  >
+                    + Add to Home
+                  </button>
+                </div>
+                <div className="p-2">
+                  <p className="text-sm text-on-surface font-medium truncate">
+                    {artwork.title}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/home/page.tsx
+++ b/src/app/admin/home/page.tsx
@@ -1,0 +1,40 @@
+import {
+  getHomePageArtworksAdmin,
+  getAvailableArtworksForHomeAdmin,
+} from "@/actions/admin/home";
+import HomePageOrderManager from "./HomePageOrderManager";
+
+export default async function AdminHomePage() {
+  const [homeArtworksResult, availableArtworksResult] = await Promise.all([
+    getHomePageArtworksAdmin(),
+    getAvailableArtworksForHomeAdmin(),
+  ]);
+
+  const homeArtworks = homeArtworksResult.data ?? [];
+  const availableArtworks = availableArtworksResult.data ?? [];
+
+  // Filter out artworks that are already on the home page from available list
+  const homeArtworkIds = new Set(homeArtworks.map((a) => a.id));
+  const notOnHomePage = availableArtworks.filter(
+    (a) => !homeArtworkIds.has(a.id),
+  );
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-on-surface">
+          Home Page Settings
+        </h1>
+        <p className="text-on-surface-variant mt-1">
+          Manage which artworks appear on the home page carousel and their
+          order.
+        </p>
+      </div>
+
+      <HomePageOrderManager
+        initialHomeArtworks={homeArtworks}
+        availableArtworks={notOnHomePage}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
-import { requireAdmin } from '@/lib/auth-utils';
+import Link from "next/link";
+import { requireAdmin } from "@/lib/auth-utils";
 
 export default async function AdminLayout({
   children,
@@ -32,6 +32,12 @@ export default async function AdminLayout({
                 >
                   Collections
                 </Link>
+                <Link
+                  href="/admin/home"
+                  className="px-3 py-2 rounded-md text-sm font-medium text-on-surface-variant hover:text-on-surface hover:bg-primary-container"
+                >
+                  Home Page
+                </Link>
               </div>
             </div>
             <Link
@@ -45,9 +51,7 @@ export default async function AdminLayout({
       </nav>
 
       {/* Admin Content */}
-      <main className="container mx-auto px-6 py-8">
-        {children}
-      </main>
+      <main className="container mx-auto px-6 py-8">{children}</main>
     </div>
   );
 }

--- a/src/components/ArtworkForm.tsx
+++ b/src/components/ArtworkForm.tsx
@@ -2,7 +2,9 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import ImageUpload from "@/components/ImageUpload";
+import MultiImageUpload, {
+  type ArtworkImage,
+} from "@/components/MultiImageUpload";
 import FacetSelector from "@/components/FacetSelector";
 import CollectionSelector, {
   type SelectedCollection,
@@ -41,6 +43,37 @@ export default function ArtworkForm({
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(!!artwork);
 
+  // Parse initial images from artwork
+  const parseInitialImages = (): ArtworkImage[] => {
+    if (!artwork) return [];
+    if (artwork.imagesJson) {
+      try {
+        return JSON.parse(artwork.imagesJson) as ArtworkImage[];
+      } catch {
+        // If parsing fails but we have a default image, create an image entry for it
+        if (artwork.defaultImageUrl) {
+          return [
+            {
+              id: `img-${Date.now()}`,
+              url: artwork.defaultImageUrl,
+              alternativeText: artwork.title,
+            },
+          ];
+        }
+      }
+    } else if (artwork.defaultImageUrl) {
+      // No imagesJson but has defaultImageUrl - create an image entry
+      return [
+        {
+          id: `img-${Date.now()}`,
+          url: artwork.defaultImageUrl,
+          alternativeText: artwork.title,
+        },
+      ];
+    }
+    return [];
+  };
+
   // Form data for direct fields
   // Note: price is passed as initialPrice prop from the server (in cents), converted to dollars for display
   const [formData, setFormData] = useState({
@@ -53,8 +86,10 @@ export default function ArtworkForm({
     depth: artwork?.depth?.toString() || "",
     dimensionUnit: artwork?.dimensionUnit || "in",
     price: initialPrice ? (initialPrice / 100).toString() : "",
-    defaultImageUrl: artwork?.defaultImageUrl || "",
   });
+
+  // Images state (separate from formData for easier management)
+  const [images, setImages] = useState<ArtworkImage[]>(parseInitialImages);
 
   // Many-to-many relationship data
   const [selectedMaterials, setSelectedMaterials] = useState<Facet[]>([]);
@@ -119,7 +154,8 @@ export default function ArtworkForm({
         depth: formData.depth ? parseFloat(formData.depth) : undefined,
         dimensionUnit: formData.dimensionUnit || undefined,
         price: formData.price ? parseFloat(formData.price) : undefined,
-        defaultImageUrl: formData.defaultImageUrl || undefined,
+        defaultImageUrl: images.length > 0 ? images[0].url : undefined,
+        imagesJson: images.length > 0 ? JSON.stringify(images) : undefined,
       };
 
       let result;
@@ -222,14 +258,9 @@ export default function ArtworkForm({
       {/* Image Upload */}
       <div>
         <label className="block text-sm font-medium text-on-surface mb-2">
-          Artwork Image
+          Artwork Images
         </label>
-        <ImageUpload
-          currentImageUrl={formData.defaultImageUrl}
-          onUploadComplete={(url) =>
-            setFormData({ ...formData, defaultImageUrl: url })
-          }
-        />
+        <MultiImageUpload images={images} onChange={setImages} />
       </div>
 
       {/* Title */}

--- a/src/components/ArtworkInfo.tsx
+++ b/src/components/ArtworkInfo.tsx
@@ -10,16 +10,18 @@ interface ArtworkInfoProps {
 export function ArtworkInfo({ artwork, className = "" }: ArtworkInfoProps) {
   return (
     <div className={`absolute bottom-5 right-4 z-[50] ${className}`}>
-      <FrostedGlass 
-        variant="dark" 
-        className="p-3 rounded-lg"
-      >
+      <FrostedGlass variant="dark" className="p-3 rounded-lg">
         <div className="flex flex-col gap-2 text-right">
           <div className="tracking-wide">
             <div className="text-xs text-white/70 font-medium uppercase">
               Name
             </div>
-            <div className="text-base text-white font-medium">{artwork.title}</div>
+            <Link
+              href={`/artworks/${artwork.slug}`}
+              className="text-base text-white font-medium hover:text-gray-200 transition-colors"
+            >
+              {artwork.title}
+            </Link>
           </div>
 
           {artwork.year && (
@@ -27,7 +29,9 @@ export function ArtworkInfo({ artwork, className = "" }: ArtworkInfoProps) {
               <div className="text-xs text-white/70 font-medium uppercase">
                 Year
               </div>
-              <div className="text-base text-white font-medium">{artwork.year}</div>
+              <div className="text-base text-white font-medium">
+                {artwork.year}
+              </div>
             </div>
           )}
 
@@ -53,4 +57,4 @@ export function ArtworkInfo({ artwork, className = "" }: ArtworkInfoProps) {
       </FrostedGlass>
     </div>
   );
-} 
+}

--- a/src/components/MultiImageUpload.tsx
+++ b/src/components/MultiImageUpload.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useState, useRef, ChangeEvent } from "react";
+import Image from "next/image";
+
+export interface ArtworkImage {
+  id: string;
+  url: string;
+  alternativeText?: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+}
+
+interface MultiImageUploadProps {
+  images: ArtworkImage[];
+  onChange: (images: ArtworkImage[]) => void;
+  className?: string;
+}
+
+interface UploadResponse {
+  success: boolean;
+  url: string;
+  fileName: string;
+  fileSize: number;
+  fileType: string;
+  error?: string;
+}
+
+export default function MultiImageUpload({
+  images,
+  onChange,
+  className = "",
+}: MultiImageUploadProps) {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const generateId = () =>
+    `img-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    const validTypes = [
+      "image/jpeg",
+      "image/jpg",
+      "image/png",
+      "image/gif",
+      "image/webp",
+      "image/svg+xml",
+    ];
+
+    setUploading(true);
+    setError(null);
+
+    const newImages: ArtworkImage[] = [];
+
+    for (const file of Array.from(files)) {
+      // Validate file type
+      if (!validTypes.includes(file.type)) {
+        setError(
+          "Please select valid image files (JPEG, PNG, GIF, WebP, or SVG)",
+        );
+        continue;
+      }
+
+      // Validate file size (10MB)
+      if (file.size > 10 * 1024 * 1024) {
+        setError("Each file must be less than 10MB");
+        continue;
+      }
+
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+
+        const response = await fetch("/api/upload", {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!response.ok) {
+          const errorData = (await response.json()) as { error?: string };
+          throw new Error(errorData.error || "Upload failed");
+        }
+
+        const data: UploadResponse = await response.json();
+
+        if (data.success && data.url) {
+          newImages.push({
+            id: generateId(),
+            url: data.url,
+            alternativeText: file.name.replace(/\.[^/.]+$/, ""),
+          });
+        }
+      } catch (err) {
+        console.error("Upload error:", err);
+        setError(err instanceof Error ? err.message : "Failed to upload image");
+      }
+    }
+
+    if (newImages.length > 0) {
+      onChange([...images, ...newImages]);
+    }
+
+    setUploading(false);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleRemove = (index: number) => {
+    const newImages = images.filter((_, i) => i !== index);
+    onChange(newImages);
+  };
+
+  const handleDragStart = (index: number) => {
+    setDraggedIndex(index);
+  };
+
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    setDragOverIndex(index);
+  };
+
+  const handleDragEnd = () => {
+    if (
+      draggedIndex !== null &&
+      dragOverIndex !== null &&
+      draggedIndex !== dragOverIndex
+    ) {
+      const newImages = [...images];
+      const [removed] = newImages.splice(draggedIndex, 1);
+      newImages.splice(dragOverIndex, 0, removed);
+      onChange(newImages);
+    }
+    setDraggedIndex(null);
+    setDragOverIndex(null);
+  };
+
+  const handleMoveUp = (index: number) => {
+    if (index === 0) return;
+    const newImages = [...images];
+    [newImages[index - 1], newImages[index]] = [
+      newImages[index],
+      newImages[index - 1],
+    ];
+    onChange(newImages);
+  };
+
+  const handleMoveDown = (index: number) => {
+    if (index === images.length - 1) return;
+    const newImages = [...images];
+    [newImages[index], newImages[index + 1]] = [
+      newImages[index + 1],
+      newImages[index],
+    ];
+    onChange(newImages);
+  };
+
+  const handleSetPrimary = (index: number) => {
+    if (index === 0) return;
+    const newImages = [...images];
+    const [removed] = newImages.splice(index, 1);
+    newImages.unshift(removed);
+    onChange(newImages);
+  };
+
+  return (
+    <div className={className}>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={handleFileChange}
+        className="hidden"
+      />
+
+      {/* Image Grid */}
+      {images.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mb-4">
+          {images.map((image, index) => (
+            <div
+              key={image.id}
+              draggable
+              onDragStart={() => handleDragStart(index)}
+              onDragOver={(e) => handleDragOver(e, index)}
+              onDragEnd={handleDragEnd}
+              className={`relative group border rounded-lg overflow-hidden ${
+                dragOverIndex === index ? "ring-2 ring-primary" : ""
+              } ${draggedIndex === index ? "opacity-50" : ""}`}
+            >
+              <div className="aspect-square relative">
+                <Image
+                  src={image.url}
+                  alt={image.alternativeText || `Image ${index + 1}`}
+                  fill
+                  className="object-cover"
+                  unoptimized
+                />
+              </div>
+
+              {/* Primary badge */}
+              {index === 0 && (
+                <div className="absolute top-2 left-2 bg-primary text-on-primary text-xs px-2 py-1 rounded">
+                  Primary
+                </div>
+              )}
+
+              {/* Order number */}
+              <div className="absolute top-2 right-2 bg-black/60 text-white text-xs px-2 py-1 rounded">
+                {index + 1}
+              </div>
+
+              {/* Hover controls */}
+              <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-1">
+                {/* Move up */}
+                <button
+                  type="button"
+                  onClick={() => handleMoveUp(index)}
+                  disabled={index === 0}
+                  className="p-1.5 bg-white/90 rounded hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Move up"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M5 15l7-7 7 7"
+                    />
+                  </svg>
+                </button>
+
+                {/* Move down */}
+                <button
+                  type="button"
+                  onClick={() => handleMoveDown(index)}
+                  disabled={index === images.length - 1}
+                  className="p-1.5 bg-white/90 rounded hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Move down"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </button>
+
+                {/* Set as primary */}
+                {index !== 0 && (
+                  <button
+                    type="button"
+                    onClick={() => handleSetPrimary(index)}
+                    className="p-1.5 bg-white/90 rounded hover:bg-white"
+                    title="Set as primary"
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
+                      />
+                    </svg>
+                  </button>
+                )}
+
+                {/* Remove */}
+                <button
+                  type="button"
+                  onClick={() => handleRemove(index)}
+                  className="p-1.5 bg-red-600 text-white rounded hover:bg-red-700"
+                  title="Remove"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
+
+              {/* Drag handle indicator */}
+              <div className="absolute bottom-2 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="bg-white/90 px-2 py-1 rounded text-xs text-gray-600">
+                  Drag to reorder
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Upload button */}
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={uploading}
+        className="btn bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-400 border-0 px-6 py-3"
+      >
+        {uploading ? (
+          <>
+            <span className="loading loading-spinner loading-sm mr-2"></span>
+            Uploading...
+          </>
+        ) : (
+          <>
+            <svg
+              className="w-5 h-5 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            Add Images
+          </>
+        )}
+      </button>
+      <p className="text-sm text-on-surface-variant mt-2">
+        Supported: JPEG, PNG, GIF, WebP, SVG (Max 10MB each). First image is the
+        primary image.
+      </p>
+
+      {error && (
+        <div className="bg-red-50 border border-red-300 rounded-lg p-3 mt-3">
+          <p className="text-red-800 text-sm">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -52,6 +52,7 @@ export const artworks = sqliteTable(
     dimensionUnit: text("dimension_unit").default("in"), // 'in', 'cm', 'mm'
     defaultImageUrl: text("default_image_url"),
     imagesJson: text("images_json"), // JSON array of image objects
+    homePageOrder: integer("home_page_order"), // Order on home page (null = not on home page)
     publishedAt: integer("published_at", { mode: "timestamp" }),
     locale: text("locale").notNull().default("en"),
     createdAt: integer("created_at", { mode: "timestamp" })

--- a/src/models/artwork.ts
+++ b/src/models/artwork.ts
@@ -33,7 +33,7 @@
  * ```
  */
 
-import { eq, inArray, and, isNotNull, isNull } from "drizzle-orm";
+import { eq, inArray, and, isNotNull, isNull, asc } from "drizzle-orm";
 import {
   db,
   artworks,
@@ -63,6 +63,10 @@ export interface ArtworkFilters {
   locale?: string[];
   /** Filter by default for collection status */
   isDefaultForCollection?: boolean;
+  /** Filter by home page presence (true = has homePageOrder, false = no homePageOrder) */
+  onHomePage?: boolean;
+  /** Order by homePageOrder ascending */
+  orderByHomePageOrder?: boolean;
 }
 
 /**
@@ -107,11 +111,26 @@ export async function findArtworks(
     conditions.push(inArray(artworks.locale, filters.locale));
   }
 
+  if (filters.onHomePage === true) {
+    conditions.push(isNotNull(artworks.homePageOrder));
+  } else if (filters.onHomePage === false) {
+    conditions.push(isNull(artworks.homePageOrder));
+  }
+
   // Execute query with conditions
   const query = db.select().from(artworks);
 
   if (conditions.length > 0) {
+    if (filters.orderByHomePageOrder) {
+      return await query
+        .where(and(...conditions))
+        .orderBy(asc(artworks.homePageOrder));
+    }
     return await query.where(and(...conditions));
+  }
+
+  if (filters.orderByHomePageOrder) {
+    return await query.orderBy(asc(artworks.homePageOrder));
   }
 
   return await query;
@@ -153,6 +172,12 @@ export async function findArtworksWithCollections(
     artworkConditions.push(inArray(artworks.locale, filters.locale));
   }
 
+  if (filters.onHomePage === true) {
+    artworkConditions.push(isNotNull(artworks.homePageOrder));
+  } else if (filters.onHomePage === false) {
+    artworkConditions.push(isNull(artworks.homePageOrder));
+  }
+
   // Build WHERE conditions for junction table
   if (filters.collectionId && filters.collectionId.length > 0) {
     junctionConditions.push(
@@ -173,12 +198,27 @@ export async function findArtworksWithCollections(
   // Get artworks first
   let matchedArtworks: SelectArtwork[];
   if (artworkConditions.length > 0) {
-    matchedArtworks = await db
-      .select()
-      .from(artworks)
-      .where(and(...artworkConditions));
+    if (filters.orderByHomePageOrder) {
+      matchedArtworks = await db
+        .select()
+        .from(artworks)
+        .where(and(...artworkConditions))
+        .orderBy(asc(artworks.homePageOrder));
+    } else {
+      matchedArtworks = await db
+        .select()
+        .from(artworks)
+        .where(and(...artworkConditions));
+    }
   } else {
-    matchedArtworks = await db.select().from(artworks);
+    if (filters.orderByHomePageOrder) {
+      matchedArtworks = await db
+        .select()
+        .from(artworks)
+        .orderBy(asc(artworks.homePageOrder));
+    } else {
+      matchedArtworks = await db.select().from(artworks);
+    }
   }
 
   if (matchedArtworks.length === 0) {


### PR DESCRIPTION
- Add MultiImageUpload component for managing multiple artwork images with drag-and-drop reordering, primary image selection, and removal
- Update ArtworkForm to use MultiImageUpload, storing images in imagesJson field with first image as defaultImageUrl
- Add homePageOrder field to artworks schema for custom home page ordering
- Create admin home page settings (/admin/home) for managing carousel artworks with drag-and-drop ordering, add/remove functionality
- Update home page data fetching to use homePageOrder with fallback to isDefaultForCollection for backwards compatibility
- Add artwork page links to home page carousel info overlay