### PR TITLE
fix: new artwork navigation in admin panel

### DIFF
--- a/src/app/admin/artworks/[slug]/page.tsx
+++ b/src/app/admin/artworks/[slug]/page.tsx
@@ -24,6 +24,7 @@ export default async function EditArtworkPage({
       </h1>
       <div className="bg-surface rounded-lg shadow-md p-8 border border-outline">
         <ArtworkForm
+          key={artworkWithProduct.slug}
           artwork={artworkWithProduct}
           initialPrice={artworkWithProduct.product?.price}
         />

--- a/src/app/admin/artworks/new/page.tsx
+++ b/src/app/admin/artworks/new/page.tsx
@@ -1,11 +1,15 @@
-import ArtworkForm from '@/components/ArtworkForm';
+import ArtworkForm from "@/components/ArtworkForm";
+
+export const dynamic = "force-dynamic";
 
 export default function NewArtworkPage() {
   return (
     <div className="max-w-3xl mx-auto">
-      <h1 className="text-3xl font-bold text-on-background mb-8">Create New Artwork</h1>
+      <h1 className="text-3xl font-bold text-on-background mb-8">
+        Create New Artwork
+      </h1>
       <div className="bg-surface rounded-lg shadow-md p-8 border border-outline">
-        <ArtworkForm />
+        <ArtworkForm key="new" />
       </div>
     </div>
   );


### PR DESCRIPTION
Add force-dynamic export and key props to ArtworkForm components to prevent Next.js caching and ensure React properly remounts the form when navigating between new and edit artwork pages.