### PR TITLE
refactor(routes): replace force-dynamic with revalidate on public routes

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,12 +1,13 @@
-// Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+// Near-static content; daily revalidation is plenty.
+export const revalidate = 86400;
 
 export default function AboutPage() {
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-4xl font-bold mb-4">About</h1>
       <p className="text-lg text-gray-600">
-        Page temporarily unavailable. Content will be added from database fixtures.
+        Page temporarily unavailable. Content will be added from database
+        fixtures.
       </p>
     </div>
   );

--- a/src/app/artworks/[slug]/page.tsx
+++ b/src/app/artworks/[slug]/page.tsx
@@ -8,8 +8,8 @@ import type { SelectCollection } from "@/database";
 import { PurchaseButton } from "@/components/PurchaseButton";
 import PostCard from "@/components/PostCard";
 
-// Force dynamic rendering - disable build-time caching
-export const dynamic = "force-dynamic";
+// Admin artwork mutations call revalidatePath('/artworks/[slug]'); 5min TTL is the safety net.
+export const revalidate = 300;
 
 interface ArtworkPageProps {
   params: Promise<{

--- a/src/app/artworks/page.tsx
+++ b/src/app/artworks/page.tsx
@@ -3,8 +3,8 @@ import Image from "@/components/Image";
 import Link from "next/link";
 import type { ArtworkWithProductAndCollections } from "@/models/artwork";
 
-// Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+// Admin artwork mutations call revalidatePath('/artworks'); 5min TTL is the safety net.
+export const revalidate = 300;
 
 function ArtworkCard({
   artwork,

--- a/src/app/collections/[slug]/page.tsx
+++ b/src/app/collections/[slug]/page.tsx
@@ -7,8 +7,8 @@ import { FrostedGlass } from "@/components/ui/FrostedGlass";
 import { notFound } from "next/navigation";
 import PostCard from "@/components/PostCard";
 
-// Force dynamic rendering - disable build-time caching
-export const dynamic = "force-dynamic";
+// Admin collection mutations revalidate admin paths; 5min TTL covers public collection-detail freshness.
+export const revalidate = 300;
 
 interface CollectionPageProps {
   params: Promise<{

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -1,11 +1,11 @@
 import { getAllCollections } from "@/actions/collection";
 import { CollectionsCarousel } from "@/components/CollectionsCarousel";
 
-// Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+// Admin collection mutations call revalidatePath('/admin/collections'); 5min TTL is the safety net for the public list.
+export const revalidate = 300;
 
 export default async function CollectionsPage() {
   const { data } = await getAllCollections();
 
   return <CollectionsCarousel collections={data} />;
-} 
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,9 +22,6 @@ export const viewport: Viewport = {
   initialScale: 1,
 };
 
-// Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
-
 export default async function RootLayout({
   children,
 }: Readonly<{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
 import HomePageArtworkCarousel from "@/components/HomePageArtworkCarousel";
 import { getHomePageData } from "@/actions/home";
 
-// Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+// Curated homepage carousel — admin updates trigger revalidatePath('/'); 60s TTL is the safety net.
+export const revalidate = 60;
 
 export default async function Home() {
   const { slides } = await getHomePageData();

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -6,7 +6,8 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
 
-export const dynamic = "force-dynamic";
+// Admin post mutations call revalidatePath('/posts/[slug]'); blog content is low-velocity, 10min TTL fallback.
+export const revalidate = 600;
 
 const POST_TYPE_LABELS: Record<string, string> = {
   announcement: "Announcement",

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -3,7 +3,8 @@ import { getAllPublishedPosts } from "@/actions/post";
 import PostCard from "@/components/PostCard";
 import type { PostType } from "@/database/schema.posts";
 
-export const dynamic = "force-dynamic";
+// Admin post mutations call revalidatePath('/posts'); searchParams (?type=) auto-opt dynamic at request time.
+export const revalidate = 300;
 
 const POST_TYPE_LABELS: Record<string, string> = {
   announcement: "Announcements",

--- a/src/app/store/[slug]/page.tsx
+++ b/src/app/store/[slug]/page.tsx
@@ -1,12 +1,12 @@
-import { notFound } from 'next/navigation';
-import Link from 'next/link';
-import Image from '@/components/Image';
-import { getProductBySlug } from '@/actions/product';
-import { PurchaseButton } from '@/components/PurchaseButton';
-import type { ProductWithArtwork } from '@/models/product';
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import Image from "@/components/Image";
+import { getProductBySlug } from "@/actions/product";
+import { PurchaseButton } from "@/components/PurchaseButton";
+import type { ProductWithArtwork } from "@/models/product";
 
-// Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+// Admin product mutations call revalidatePath('/store/[slug]'); 2min TTL guards pricing/availability freshness.
+export const revalidate = 120;
 
 interface ProductPageProps {
   params: Promise<{ slug: string }>;
@@ -51,9 +51,13 @@ export default async function ProductPage({ params }: ProductPageProps) {
     <main className="container mx-auto px-4 py-8">
       {/* Breadcrumb */}
       <nav className="flex items-center gap-2 text-sm text-on-surface-variant mb-8">
-        <Link href="/" className="hover:text-primary transition-colors">Home</Link>
+        <Link href="/" className="hover:text-primary transition-colors">
+          Home
+        </Link>
         <span>/</span>
-        <Link href="/store" className="hover:text-primary transition-colors">Shop</Link>
+        <Link href="/store" className="hover:text-primary transition-colors">
+          Shop
+        </Link>
         <span>/</span>
         <span className="text-on-surface">{product.name}</span>
       </nav>
@@ -69,7 +73,9 @@ export default async function ProductPage({ params }: ProductPageProps) {
               {product.name}
             </h1>
             {artwork?.artist && (
-              <p className="text-lg text-on-surface-variant">by {artwork.artist}</p>
+              <p className="text-lg text-on-surface-variant">
+                by {artwork.artist}
+              </p>
             )}
             {artwork?.year && (
               <p className="text-on-surface-variant">{artwork.year}</p>
@@ -83,17 +89,39 @@ export default async function ProductPage({ params }: ProductPageProps) {
 
           {/* What's Included */}
           <div className="bg-primary-container/10 border border-primary/20 rounded-lg p-4">
-            <h3 className="font-semibold text-on-surface mb-3">What&apos;s Included</h3>
+            <h3 className="font-semibold text-on-surface mb-3">
+              What&apos;s Included
+            </h3>
             <ul className="space-y-2 text-sm text-on-surface-variant">
               <li className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                <svg
+                  className="w-4 h-4 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
                 </svg>
                 Original artwork
               </li>
               <li className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                <svg
+                  className="w-4 h-4 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
                 </svg>
                 Secure packaging and shipping
               </li>
@@ -102,7 +130,9 @@ export default async function ProductPage({ params }: ProductPageProps) {
 
           {description && (
             <div>
-              <h2 className="text-lg font-semibold text-on-surface mb-3">Description</h2>
+              <h2 className="text-lg font-semibold text-on-surface mb-3">
+                Description
+              </h2>
               <p className="text-on-surface leading-relaxed whitespace-pre-line">
                 {description}
               </p>
@@ -112,12 +142,14 @@ export default async function ProductPage({ params }: ProductPageProps) {
           {/* Dimensions (from artwork) */}
           {artwork && (artwork.width || artwork.height || artwork.depth) && (
             <div>
-              <h2 className="text-lg font-semibold text-on-surface mb-3">Dimensions</h2>
+              <h2 className="text-lg font-semibold text-on-surface mb-3">
+                Dimensions
+              </h2>
               <p className="text-on-surface-variant">
                 {[artwork.width, artwork.height, artwork.depth]
                   .filter(Boolean)
-                  .join(' x ')}{' '}
-                {artwork.dimensionUnit || 'in'}
+                  .join(" x ")}{" "}
+                {artwork.dimensionUnit || "in"}
               </p>
             </div>
           )}
@@ -130,8 +162,18 @@ export default async function ProductPage({ params }: ProductPageProps) {
           href="/store"
           className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back to Shop
         </Link>
@@ -145,7 +187,7 @@ export async function generateMetadata({ params }: ProductPageProps) {
   const product = await getProductBySlug(slug);
 
   if (!product) {
-    return { title: 'Product Not Found | EONMUN' };
+    return { title: "Product Not Found | EONMUN" };
   }
 
   return {

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -1,19 +1,19 @@
-import { Metadata } from 'next';
-import Link from 'next/link';
-import Image from '@/components/Image';
-import { getAvailableProductsWithArtwork } from '@/actions/product';
-import { getAllCollections } from '@/actions/collection';
-import { PurchaseButton } from '@/components/PurchaseButton';
-import { FrostedGlass } from '@/components/ui/FrostedGlass';
-import type { ProductWithArtwork } from '@/models/product';
+import { Metadata } from "next";
+import Link from "next/link";
+import Image from "@/components/Image";
+import { getAvailableProductsWithArtwork } from "@/actions/product";
+import { getAllCollections } from "@/actions/collection";
+import { PurchaseButton } from "@/components/PurchaseButton";
+import { FrostedGlass } from "@/components/ui/FrostedGlass";
+import type { ProductWithArtwork } from "@/models/product";
 
 export const metadata: Metadata = {
-  title: 'Shop | EONMUN',
-  description: 'Shop original artworks by EONMUN.',
+  title: "Shop | EONMUN",
+  description: "Shop original artworks by EONMUN.",
 };
 
-// Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+// Admin product mutations call revalidatePath('/store'); 2min TTL guards pricing/availability freshness.
+export const revalidate = 120;
 
 function ProductCard({ product }: { product: ProductWithArtwork }) {
   const priceInDollars = product.price / 100;
@@ -21,7 +21,7 @@ function ProductCard({ product }: { product: ProductWithArtwork }) {
   const description = product.description || product.artwork?.description;
 
   return (
-    <div 
+    <div
       className="group bg-surface border border-outline rounded-lg overflow-hidden hover:shadow-lg transition-shadow"
       data-testid="product-card"
     >
@@ -47,7 +47,9 @@ function ProductCard({ product }: { product: ProductWithArtwork }) {
                   {product.name}
                 </h3>
                 {product.artwork?.year && (
-                  <p className="text-gray-300 text-sm">{product.artwork.year}</p>
+                  <p className="text-gray-300 text-sm">
+                    {product.artwork.year}
+                  </p>
                 )}
                 {description && (
                   <p className="text-gray-300 text-sm mt-2 line-clamp-2">
@@ -66,24 +68,29 @@ function ProductCard({ product }: { product: ProductWithArtwork }) {
             {product.name}
           </h3>
           {product.artwork?.year && (
-            <p className="text-sm text-on-surface-variant">{product.artwork.year}</p>
+            <p className="text-sm text-on-surface-variant">
+              {product.artwork.year}
+            </p>
           )}
         </Link>
 
         <div className="flex items-center justify-between">
-          <span className="text-xl font-bold text-primary" data-testid="product-price">
+          <span
+            className="text-xl font-bold text-primary"
+            data-testid="product-price"
+          >
             ${priceInDollars.toLocaleString()}
           </span>
         </div>
 
-        <PurchaseButton 
+        <PurchaseButton
           product={{
             id: product.id,
             name: product.name,
             slug: product.slug,
             price: product.price,
-          }} 
-          variant="compact" 
+          }}
+          variant="compact"
         />
       </div>
     </div>
@@ -91,7 +98,9 @@ function ProductCard({ product }: { product: ProductWithArtwork }) {
 }
 
 export default async function StorePage() {
-  const { data: products } = await getAvailableProductsWithArtwork({ type: 'artwork' });
+  const { data: products } = await getAvailableProductsWithArtwork({
+    type: "artwork",
+  });
   const { data: collections } = await getAllCollections();
 
   return (
@@ -110,10 +119,7 @@ export default async function StorePage() {
             <h2 className="font-semibold text-on-surface mb-4">Collections</h2>
             <ul className="space-y-2">
               <li>
-                <Link
-                  href="/store"
-                  className="text-primary hover:underline"
-                >
+                <Link href="/store" className="text-primary hover:underline">
                   All Products
                 </Link>
               </li>


### PR DESCRIPTION
Closes #54.

## Summary

Replaces this branch's predecessor (`copilot/remove-no-caching-rules` on PR #54) which had grown stale enough that rebasing would have deleted ~24k lines of work — blog/posts, the homepage carousel admin, GTM, contact-email config. Redone cleanly off latest `master`.

## The load-bearing fix

`src/app/layout.tsx` had `export const dynamic = 'force-dynamic'`. Root-layout directives override every per-page directive, so even pages that *didn't* have `force-dynamic` were forced to render dynamically. Removing it on the layout is what actually unlocks ISR.

## Routes changed

| Route | Now | Why |
|---|---|---|
| `app/layout.tsx` | (removed) | Root-layout poison pill — see above |
| `app/page.tsx` | `revalidate = 60` | Homepage carousel; on-demand revalidated by `actions/admin/homepage.ts` |
| `app/about/page.tsx` | `revalidate = 86400` | Near-static |
| `app/artworks/page.tsx` | `revalidate = 300` | On-demand revalidated by admin/artwork actions |
| `app/artworks/[slug]/page.tsx` | `revalidate = 300` | Same |
| `app/collections/page.tsx` | `revalidate = 300` | On-demand revalidated by admin/collection actions |
| `app/collections/[slug]/page.tsx` | `revalidate = 300` | Same |
| `app/store/page.tsx` | `revalidate = 120` | Pricing/availability volatility — conservative TTL |
| `app/store/[slug]/page.tsx` | `revalidate = 120` | Same |
| `app/posts/page.tsx` | `revalidate = 300` | Lower-velocity, but `?type=` searchParams auto-opt dynamic |
| `app/posts/[slug]/page.tsx` | `revalidate = 600` | Lowest-velocity content |

## Intentionally still dynamic

- `app/contact/page.tsx` — searchParams + redirect-driven UX
- `app/admin/**` — auth-gated
- `app/nfts/**`, `app/purchase/success/page.tsx`, `app/stripe-demo/page.tsx` — chain reads / live Stripe / per-request

## Quality gates

- typecheck: clean
- lint: clean (only pre-existing `<img>` warnings)
- build: succeeds
- e2e: deferred to CI (sandbox couldn't pull libsql container)

## Important caveat (filed as follow-up)

Build output still labels routes as `ƒ (Dynamic)`, not `● (ISR)`. The `revalidate` directive sets the contract, but Drizzle/libSQL data fetches don't interact with Next's fetch cache, so HTML doesn't materialize as ISR until accessors are wrapped in `unstable_cache` with tags + `revalidateTag` calls in admin actions. **That's a follow-up PR**; this PR fixes the directives, which is the prerequisite.

OpenNext + Cloudflare R2/D1 cache infra (`r2IncrementalCache`, `doQueue`, `d1NextTagCache`) is also out of scope — needs Cloudflare-side provisioning.

## Test plan

- [ ] CI green (lint, typecheck, Playwright E2E, Workers Build)
- [ ] After merge: confirm a build of master shows `● (ISR)` for at least one public route once the follow-up `unstable_cache` PR lands