### PR TITLE
feat(analytics): implement tracking gaps from audit

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,9 +1,12 @@
-import posthog from "posthog-js"
+import posthog from "posthog-js";
 
+// Per analytics audit (issue #59, task 3.2): the `defaults: '2025-05-24'`
+// option was removed because it switches `capture_pageview` to
+// `'history_change'`, which double-fires on Next.js App Router navigations.
+// Pageviews are captured via the SDK default behaviour instead.
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: "/ingest",
   ui_host: "https://us.posthog.com",
-  defaults: '2025-05-24',
-  capture_exceptions: true, // This enables capturing exceptions using Error Tracking, set to false if you don't want this
+  capture_exceptions: true, // Enables Error Tracking exception capture
   debug: process.env.NODE_ENV === "development",
 });

--- a/src/actions/contact.ts
+++ b/src/actions/contact.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation";
 import { createTransport } from "nodemailer";
+import { ANALYTICS_EVENTS, captureServerEvent } from "@/lib/analytics-server";
 
 export async function submitContactForm(data: FormData) {
   const name = data.get("name") as string;
@@ -21,7 +22,9 @@ export async function submitContactForm(data: FormData) {
 
   // Get SMTP configuration from environment variables
   const smtpHost = process.env.SMTP_HOST;
-  const smtpPort = process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT) : 587;
+  const smtpPort = process.env.SMTP_PORT
+    ? parseInt(process.env.SMTP_PORT)
+    : 587;
   const smtpUser = process.env.SMTP_USER;
   const smtpPass = process.env.SMTP_PASS;
   const smtpFrom = process.env.SMTP_FROM;
@@ -97,6 +100,23 @@ This message was sent from the EONMUN contact form.
     console.error("Error sending email:", error);
     errorMessage = "Failed to send email";
   }
+
+  // Capture analytics regardless of success so we can detect SMTP failures
+  // as a drop-off in the funnel. Use the submitter email as distinct id so
+  // PostHog can join with later activity if they sign in.
+  await captureServerEvent({
+    event: ANALYTICS_EVENTS.CONTACT_FORM_SUBMITTED,
+    distinctId: email,
+    properties: {
+      // PRIVACY: do not store the message body — only metadata about the submission.
+      email_sent: emailSent,
+      message_length: message.length,
+      // SECURITY: capture the email domain (but not the local-part) for routing
+      // analysis without storing PII unnecessarily. Full email is the distinct id.
+      email_domain: email.split("@")[1] ?? null,
+      error: emailSent ? null : errorMessage,
+    },
+  });
 
   // Handle redirects outside of try/catch block
   if (emailSent) {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,21 +1,22 @@
-import { NextRequest, NextResponse } from 'next/server';
-import Stripe from 'stripe';
-import { stripe } from '@/lib/stripe-server';
-import { markProductSold, decrementProductQuantity } from '@/models/product';
-import { findProducts } from '@/models/product';
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import { stripe } from "@/lib/stripe-server";
+import { markProductSold, decrementProductQuantity } from "@/models/product";
+import { findProducts } from "@/models/product";
+import { ANALYTICS_EVENTS, captureServerEvent } from "@/lib/analytics-server";
 
 export async function POST(request: NextRequest) {
   try {
     const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
     const body = await request.text();
-    const signature = request.headers.get('stripe-signature');
+    const signature = request.headers.get("stripe-signature");
 
     if (!signature) {
-      console.error('Missing stripe-signature header');
+      console.error("Missing stripe-signature header");
       return NextResponse.json(
-        { error: 'Missing stripe-signature header' },
-        { status: 400 }
+        { error: "Missing stripe-signature header" },
+        { status: 400 },
       );
     }
 
@@ -26,26 +27,30 @@ export async function POST(request: NextRequest) {
       try {
         event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
       } catch (err) {
-        console.error('Webhook signature verification failed:', err);
+        console.error("Webhook signature verification failed:", err);
         return NextResponse.json(
-          { error: 'Webhook signature verification failed' },
-          { status: 400 }
+          { error: "Webhook signature verification failed" },
+          { status: 400 },
         );
       }
     } else {
       // In development without webhook secret, parse the event directly
-      console.warn('STRIPE_WEBHOOK_SECRET not configured - skipping signature verification');
+      console.warn(
+        "STRIPE_WEBHOOK_SECRET not configured - skipping signature verification",
+      );
       event = JSON.parse(body) as Stripe.Event;
     }
 
     // Handle the event
     switch (event.type) {
-      case 'checkout.session.completed': {
+      case "checkout.session.completed": {
         const session = event.data.object as Stripe.Checkout.Session;
 
         // Verify payment was actually completed
-        if (session.payment_status !== 'paid') {
-          console.log(`Payment not completed for session ${session.id}, status: ${session.payment_status}`);
+        if (session.payment_status !== "paid") {
+          console.log(
+            `Payment not completed for session ${session.id}, status: ${session.payment_status}`,
+          );
           return NextResponse.json({ received: true });
         }
 
@@ -53,10 +58,10 @@ export async function POST(request: NextRequest) {
         const productId = session.metadata?.productId;
 
         if (!productId) {
-          console.error('No productId in session metadata');
+          console.error("No productId in session metadata");
           return NextResponse.json(
-            { error: 'No productId in session metadata' },
-            { status: 400 }
+            { error: "No productId in session metadata" },
+            { status: 400 },
           );
         }
 
@@ -68,29 +73,63 @@ export async function POST(request: NextRequest) {
         if (!product) {
           console.error(`Product not found: ${productId}`);
           return NextResponse.json(
-            { error: 'Product not found' },
-            { status: 404 }
+            { error: "Product not found" },
+            { status: 404 },
           );
         }
 
         // Handle based on product type
-        if (product.type === 'artwork') {
+        if (product.type === "artwork") {
           // Unique item - mark as sold
           const updatedProduct = await markProductSold(productIdNum);
-          console.log(`Marked product ${productId} as sold:`, updatedProduct?.soldAt);
+          console.log(
+            `Marked product ${productId} as sold:`,
+            updatedProduct?.soldAt,
+          );
         } else if (product.quantity !== null && product.quantity > 0) {
           // Quantity item - decrement stock
           const updatedProduct = await decrementProductQuantity(productIdNum);
-          console.log(`Decremented product ${productId} quantity:`, updatedProduct?.quantity);
+          console.log(
+            `Decremented product ${productId} quantity:`,
+            updatedProduct?.quantity,
+          );
         }
+
+        // Server-side analytics: trustworthy revenue source of truth.
+        // Distinct id falls back to the Stripe session id when the customer
+        // is anonymous so PostHog can still record the event.
+        await captureServerEvent({
+          event: ANALYTICS_EVENTS.PURCHASE_COMPLETED_SERVER,
+          distinctId:
+            session.customer_details?.email ||
+            (typeof session.customer === "string"
+              ? session.customer
+              : undefined) ||
+            session.id,
+          properties: {
+            transaction_id: session.id,
+            product_id: product.id,
+            product_name: product.name,
+            product_slug: product.slug,
+            product_type: product.type,
+            // Stripe amount_total is in the smallest currency unit (cents)
+            amount_total_cents: session.amount_total,
+            value:
+              session.amount_total !== null
+                ? session.amount_total / 100
+                : undefined,
+            currency: session.currency?.toUpperCase() || "USD",
+            customer_email: session.customer_details?.email || null,
+          },
+        });
 
         break;
       }
 
-      case 'checkout.session.expired': {
+      case "checkout.session.expired": {
         // Handle expired sessions if needed
         const session = event.data.object as Stripe.Checkout.Session;
-        console.log('Checkout session expired:', session.id);
+        console.log("Checkout session expired:", session.id);
         break;
       }
 
@@ -101,10 +140,10 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ received: true });
   } catch (error) {
-    console.error('Webhook error:', error);
+    console.error("Webhook error:", error);
     return NextResponse.json(
-      { error: 'Webhook handler failed' },
-      { status: 500 }
+      { error: "Webhook handler failed" },
+      { status: 500 },
     );
   }
 }

--- a/src/app/artworks/[slug]/page.tsx
+++ b/src/app/artworks/[slug]/page.tsx
@@ -7,6 +7,7 @@ import type { ArtworkWithProductAndCollections } from "@/models/artwork";
 import type { SelectCollection } from "@/database";
 import { PurchaseButton } from "@/components/PurchaseButton";
 import PostCard from "@/components/PostCard";
+import ArtworkViewedTracker from "@/components/ArtworkViewedTracker";
 
 // Force dynamic rendering - disable build-time caching
 export const dynamic = "force-dynamic";
@@ -109,6 +110,16 @@ export default async function ArtworkPage(props: ArtworkPageProps) {
 
   return (
     <div className="container mx-auto px-4 py-8">
+      {/* Client-side analytics: top of the purchase funnel */}
+      <ArtworkViewedTracker
+        artworkId={artwork.id}
+        artworkSlug={artwork.slug}
+        artworkTitle={artwork.title}
+        artist={artwork.artist}
+        year={artwork.year}
+        priceCents={artwork.product?.price ?? null}
+        collections={artwork.collections?.map((c) => c.slug)}
+      />
       {/* Breadcrumb */}
       <div className="flex items-center gap-2 text-sm text-on-surface-variant mb-8">
         <Link href="/" className="hover:text-primary transition-colors">

--- a/src/app/purchase/success/page.tsx
+++ b/src/app/purchase/success/page.tsx
@@ -1,6 +1,7 @@
-import Link from 'next/link';
-import { getProductBySlug } from '@/actions/product';
-import Image from '@/components/Image';
+import Link from "next/link";
+import { getProductBySlug } from "@/actions/product";
+import Image from "@/components/Image";
+import PurchaseSuccessTracker from "@/components/PurchaseSuccessTracker";
 
 interface SuccessPageProps {
   searchParams: Promise<{
@@ -17,6 +18,14 @@ export default async function PurchaseSuccessPage(props: SuccessPageProps) {
 
   return (
     <div className="container mx-auto px-4 py-12">
+      {/* Client-side analytics: completes the purchase funnel started in PurchaseButton */}
+      <PurchaseSuccessTracker
+        sessionId={session_id}
+        productId={product?.id}
+        productName={product?.name}
+        productSlug={product?.slug}
+        priceCents={product?.price}
+      />
       <div className="max-w-2xl mx-auto text-center">
         {/* Success Icon */}
         <div className="mx-auto w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mb-6">
@@ -38,9 +47,10 @@ export default async function PurchaseSuccessPage(props: SuccessPageProps) {
         <h1 className="text-4xl font-bold text-on-background mb-4">
           Purchase Successful!
         </h1>
-        
+
         <p className="text-xl text-on-surface-variant mb-8">
-          Thank you for your purchase. Your payment has been processed successfully.
+          Thank you for your purchase. Your payment has been processed
+          successfully.
         </p>
 
         {/* Product Details */}
@@ -54,7 +64,9 @@ export default async function PurchaseSuccessPage(props: SuccessPageProps) {
               {(product.imageUrl || product.artwork?.defaultImageUrl) && (
                 <div className="w-24 h-24 rounded-lg overflow-hidden border border-outline">
                   <Image
-                    src={product.imageUrl || product.artwork?.defaultImageUrl || ''}
+                    src={
+                      product.imageUrl || product.artwork?.defaultImageUrl || ""
+                    }
                     alt={product.name}
                     className="w-full h-full object-cover"
                   />
@@ -66,10 +78,16 @@ export default async function PurchaseSuccessPage(props: SuccessPageProps) {
                   {product.name}
                 </h3>
                 {product.artwork?.year && (
-                  <p className="text-on-surface-variant">{product.artwork.year}</p>
+                  <p className="text-on-surface-variant">
+                    {product.artwork.year}
+                  </p>
                 )}
                 <p className="text-lg font-semibold text-green-600 mt-1">
-                  ${(product.price / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                  $
+                  {(product.price / 100).toLocaleString("en-US", {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
                 </p>
               </div>
             </div>
@@ -136,9 +154,9 @@ export async function generateMetadata({ searchParams }: SuccessPageProps) {
   const { product_slug } = await searchParams;
 
   return {
-    title: 'Purchase Successful - EONMUN',
+    title: "Purchase Successful - EONMUN",
     description: product_slug
       ? `Successfully purchased product. Thank you for your purchase!`
-      : 'Purchase completed successfully',
+      : "Purchase completed successfully",
   };
 }

--- a/src/components/ArtworkViewedTracker.tsx
+++ b/src/components/ArtworkViewedTracker.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { ANALYTICS_EVENTS, captureEvent } from "@/lib/analytics";
+
+interface ArtworkViewedTrackerProps {
+  artworkId: number;
+  artworkSlug: string;
+  artworkTitle: string;
+  artist?: string | null;
+  year?: number | null;
+  /** Price in cents if the artwork is for sale (linked product). */
+  priceCents?: number | null;
+  collections?: string[];
+}
+
+/**
+ * Fires `artwork_viewed` once per mount.
+ *
+ * Mounting on every navigation is the desired behaviour — we want to count
+ * each detail-page view, not each unique session. The `fired` ref only
+ * guards against React 18 Strict Mode double-invocation in development.
+ */
+export default function ArtworkViewedTracker({
+  artworkId,
+  artworkSlug,
+  artworkTitle,
+  artist,
+  year,
+  priceCents,
+  collections,
+}: ArtworkViewedTrackerProps) {
+  const fired = useRef(false);
+
+  useEffect(() => {
+    if (fired.current) return;
+    fired.current = true;
+
+    captureEvent(ANALYTICS_EVENTS.ARTWORK_VIEWED, {
+      artwork_id: artworkId,
+      artwork_slug: artworkSlug,
+      artwork_title: artworkTitle,
+      artist: artist ?? undefined,
+      year: year ?? undefined,
+      price_cents: priceCents ?? undefined,
+      value: priceCents != null ? priceCents / 100 : undefined,
+      currency: "USD",
+      collections,
+      for_sale: priceCents != null,
+    });
+  }, [
+    artworkId,
+    artworkSlug,
+    artworkTitle,
+    artist,
+    year,
+    priceCents,
+    collections,
+  ]);
+
+  return null;
+}

--- a/src/components/PurchaseButton.tsx
+++ b/src/components/PurchaseButton.tsx
@@ -1,8 +1,9 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { getStripe } from '@/lib/stripe';
-import { Button } from '@/components/ui/button';
+import { useState } from "react";
+import { getStripe } from "@/lib/stripe";
+import { Button } from "@/components/ui/button";
+import { ANALYTICS_EVENTS, captureEvent } from "@/lib/analytics";
 
 interface PurchaseButtonProps {
   product: {
@@ -11,10 +12,13 @@ interface PurchaseButtonProps {
     slug: string;
     price: number;
   };
-  variant?: 'default' | 'compact';
+  variant?: "default" | "compact";
 }
 
-export function PurchaseButton({ product, variant = 'default' }: PurchaseButtonProps) {
+export function PurchaseButton({
+  product,
+  variant = "default",
+}: PurchaseButtonProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -25,10 +29,22 @@ export function PurchaseButton({ product, variant = 'default' }: PurchaseButtonP
     setLoading(true);
     setError(null);
 
+    // Fire before the network call so a slow checkout still records intent.
+    captureEvent(ANALYTICS_EVENTS.CHECKOUT_INITIATED, {
+      product_id: product.id,
+      product_name: product.name,
+      product_slug: product.slug,
+      // price stored in cents internally; expose both for analyst convenience
+      price_cents: product.price,
+      value: product.price / 100,
+      currency: "USD",
+      variant,
+    });
+
     try {
-      const response = await fetch('/api/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const response = await fetch("/api/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           productId: product.id.toString(),
           productName: product.name,
@@ -37,37 +53,39 @@ export function PurchaseButton({ product, variant = 'default' }: PurchaseButtonP
         }),
       });
 
-      const data = await response.json() as {
+      const data = (await response.json()) as {
         sessionId?: string;
         error?: string;
         details?: string;
       };
 
       if (!response.ok) {
-        throw new Error(data.details || data.error || 'Checkout failed');
+        throw new Error(data.details || data.error || "Checkout failed");
       }
 
       const stripe = await getStripe();
       if (!stripe) {
-        throw new Error('Failed to initialize Stripe. Please check your configuration.');
+        throw new Error(
+          "Failed to initialize Stripe. Please check your configuration.",
+        );
       }
       if (data.sessionId) {
         const { error: stripeError } = await stripe.redirectToCheckout({
-          sessionId: data.sessionId
+          sessionId: data.sessionId,
         });
         if (stripeError) {
           throw new Error(stripeError.message);
         }
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
       setLoading(false);
     }
   };
 
   // Compact variant for product cards
-  if (variant === 'compact') {
+  if (variant === "compact") {
     return (
       <Button
         onClick={handlePurchase}
@@ -75,7 +93,7 @@ export function PurchaseButton({ product, variant = 'default' }: PurchaseButtonP
         size="sm"
         className="w-full"
       >
-        {loading ? 'Processing...' : 'Buy'}
+        {loading ? "Processing..." : "Buy"}
       </Button>
     );
   }
@@ -97,12 +115,10 @@ export function PurchaseButton({ product, variant = 'default' }: PurchaseButtonP
         className="w-full"
         data-testid="purchase-button"
       >
-        {loading ? 'Processing...' : 'Purchase Artwork'}
+        {loading ? "Processing..." : "Purchase Artwork"}
       </Button>
 
-      {error && (
-        <p className="text-red-600 text-sm">{error}</p>
-      )}
+      {error && <p className="text-red-600 text-sm">{error}</p>}
 
       <p className="text-xs text-on-surface-variant">
         Secure payment via Stripe. Includes certificate of authenticity.

--- a/src/components/PurchaseSuccessTracker.tsx
+++ b/src/components/PurchaseSuccessTracker.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { ANALYTICS_EVENTS, captureEvent } from "@/lib/analytics";
+
+interface PurchaseSuccessTrackerProps {
+  sessionId?: string;
+  productId?: number;
+  productName?: string;
+  productSlug?: string;
+  /** Price in cents, matching the rest of the codebase. */
+  priceCents?: number;
+}
+
+/**
+ * Fires `purchase_completed` once when the success page mounts.
+ *
+ * CRITICAL: this is a complement to the server-side `purchase_completed_server`
+ * event fired from the Stripe webhook. The client event is what unlocks
+ * funnels in PostHog (it shares the visitor's distinct id with earlier
+ * events like `checkout_initiated`); the server event is the trustworthy
+ * source of truth for revenue, since clients can be blocked by extensions.
+ */
+export default function PurchaseSuccessTracker({
+  sessionId,
+  productId,
+  productName,
+  productSlug,
+  priceCents,
+}: PurchaseSuccessTrackerProps) {
+  // useRef guards against React 18 Strict Mode double-invocation in dev,
+  // which would otherwise inflate purchase counts during development.
+  const fired = useRef(false);
+
+  useEffect(() => {
+    if (fired.current) return;
+    fired.current = true;
+
+    captureEvent(ANALYTICS_EVENTS.PURCHASE_COMPLETED, {
+      transaction_id: sessionId,
+      product_id: productId,
+      product_name: productName,
+      product_slug: productSlug,
+      price_cents: priceCents,
+      value: priceCents !== undefined ? priceCents / 100 : undefined,
+      currency: "USD",
+    });
+  }, [sessionId, productId, productName, productSlug, priceCents]);
+
+  return null;
+}

--- a/src/lib/analytics-server.ts
+++ b/src/lib/analytics-server.ts
@@ -1,0 +1,66 @@
+/**
+ * Server-side PostHog capture helper.
+ *
+ * Use this from server actions, route handlers, and webhooks where the user
+ * journey can't be reliably observed client-side (e.g. Stripe webhooks,
+ * spam-protected form submissions).
+ *
+ * CRITICAL: server-side events are anonymous unless `distinctId` is provided.
+ * For purchase funnel events, prefer the Stripe customer email or session id
+ * so the event can be joined with client-side activity in PostHog.
+ */
+import PostHogClient from "@/lib/posthog-server";
+import { ANALYTICS_EVENTS, type AnalyticsEventName } from "@/lib/analytics";
+
+export { ANALYTICS_EVENTS };
+export type { AnalyticsEventName };
+
+interface ServerCaptureOptions {
+  event: AnalyticsEventName;
+  /**
+   * Unique identifier for the actor. Use the authenticated user id when
+   * available, otherwise fall back to a stable proxy (e.g. Stripe session id,
+   * customer email). PostHog requires a non-empty string.
+   */
+  distinctId: string;
+  properties?: Record<string, unknown>;
+}
+
+/**
+ * Fire a server-side PostHog capture safely.
+ *
+ * No-ops if `NEXT_PUBLIC_POSTHOG_KEY` is unset so local dev and CI don't fail
+ * loudly when analytics aren't configured.
+ */
+export async function captureServerEvent(
+  options: ServerCaptureOptions,
+): Promise<void> {
+  if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+
+  let client: ReturnType<typeof PostHogClient> | null = null;
+  try {
+    client = PostHogClient();
+    client.capture({
+      distinctId: options.distinctId,
+      event: options.event,
+      properties: options.properties,
+    });
+  } catch (error) {
+    // SECURITY: never let analytics break a webhook or server action.
+    console.error(
+      `[analytics-server] capture failed for "${options.event}":`,
+      error,
+    );
+  } finally {
+    // Posthog-node batches events; shutdown forces a flush. Required in
+    // serverless / edge environments where the function may exit before the
+    // batch interval elapses.
+    if (client) {
+      try {
+        await client.shutdown();
+      } catch (error) {
+        console.error("[analytics-server] shutdown failed:", error);
+      }
+    }
+  }
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,58 @@
+/**
+ * Analytics event names and client-side capture helpers.
+ *
+ * Events are routed through PostHog. Server-side counterparts live in
+ * `analytics-server.ts` and reuse the same event names.
+ *
+ * CRITICAL: Renaming any of these constants breaks dashboards and funnels.
+ * If you must rename, also update PostHog dashboards/insights and document
+ * the migration in the related GitHub issue.
+ *
+ * Cursor rule reference: `.cursor/rules/posthog-integration.mdc` requires
+ * event/property names to live in a single typed const object.
+ */
+import posthog from "posthog-js";
+
+export const ANALYTICS_EVENTS = {
+  // Funnel: artwork detail page view → checkout → purchase
+  ARTWORK_VIEWED: "artwork_viewed",
+  CHECKOUT_INITIATED: "checkout_initiated",
+  PURCHASE_COMPLETED: "purchase_completed",
+  PURCHASE_COMPLETED_SERVER: "purchase_completed_server",
+  // Engagement
+  CONTACT_FORM_SUBMITTED: "contact_form_submitted",
+} as const;
+
+export type AnalyticsEventName =
+  (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
+
+/**
+ * Fire a client-side PostHog capture safely.
+ *
+ * No-ops in three cases:
+ *  1. Running on the server (no `window`).
+ *  2. PostHog isn't loaded yet (e.g. blocked by extension or pre-init).
+ *  3. PostHog is uninitialized because `NEXT_PUBLIC_POSTHOG_KEY` is unset
+ *     (common in CI / preview environments).
+ *
+ * Callers should not need to check these conditions — they're handled here
+ * to keep call sites uncluttered.
+ */
+export function captureEvent(
+  event: AnalyticsEventName,
+  properties: Record<string, unknown> = {},
+): void {
+  if (typeof window === "undefined") return;
+  // posthog.__loaded becomes true after `posthog.init` finishes in the
+  // instrumentation-client. Guarding here prevents lost events queueing
+  // against an uninitialized client when the key is missing.
+  if (!posthog || !posthog.__loaded) return;
+
+  try {
+    posthog.capture(event, properties);
+  } catch (error) {
+    // SECURITY: never let a tracking failure break a user-facing flow.
+    // Log to console for debugging, then swallow.
+    console.error(`[analytics] capture failed for "${event}":`, error);
+  }
+}

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the centralized analytics helper.
+ *
+ * Coverage focus:
+ *  1. Event-name constants are stable (renames break dashboards — see
+ *     `.cursor/rules/posthog-integration.mdc`).
+ *  2. `captureEvent` no-ops when PostHog isn't loaded so call sites stay
+ *     uncluttered and analytics never breaks user-facing flows.
+ *  3. `captureEvent` forwards to `posthog.capture` with the correct args
+ *     once initialized.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from "vitest";
+
+// posthog-js exposes a default singleton; mock it so we can assert capture calls.
+vi.mock("posthog-js", () => ({
+  default: {
+    __loaded: false,
+    capture: vi.fn(),
+  },
+}));
+
+import posthog from "posthog-js";
+import { ANALYTICS_EVENTS, captureEvent } from "@/lib/analytics";
+
+// captureEvent short-circuits when `window` is undefined (server context).
+// The vitest 'node' env doesn't define `window`, so stub it here so the
+// behaviour we want to exercise is actually reachable.
+beforeAll(() => {
+  // @ts-expect-error -- intentional polyfill for the unit test
+  globalThis.window = globalThis.window ?? ({} as Window);
+});
+
+afterAll(() => {
+  // @ts-expect-error -- restore node default
+  delete globalThis.window;
+});
+
+describe("ANALYTICS_EVENTS", () => {
+  it("exports the audit-required event names verbatim", () => {
+    // CRITICAL: these strings are referenced by PostHog dashboards. Renames
+    // here must be matched in PostHog or funnels silently break.
+    expect(ANALYTICS_EVENTS.ARTWORK_VIEWED).toBe("artwork_viewed");
+    expect(ANALYTICS_EVENTS.CHECKOUT_INITIATED).toBe("checkout_initiated");
+    expect(ANALYTICS_EVENTS.PURCHASE_COMPLETED).toBe("purchase_completed");
+    expect(ANALYTICS_EVENTS.PURCHASE_COMPLETED_SERVER).toBe(
+      "purchase_completed_server",
+    );
+    expect(ANALYTICS_EVENTS.CONTACT_FORM_SUBMITTED).toBe(
+      "contact_form_submitted",
+    );
+  });
+});
+
+describe("captureEvent", () => {
+  beforeEach(() => {
+    vi.mocked(posthog.capture).mockClear();
+    (posthog as unknown as { __loaded: boolean }).__loaded = false;
+  });
+
+  it("no-ops when PostHog has not finished loading", () => {
+    captureEvent(ANALYTICS_EVENTS.ARTWORK_VIEWED, { artwork_id: 1 });
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it("forwards to posthog.capture with event name and properties once loaded", () => {
+    (posthog as unknown as { __loaded: boolean }).__loaded = true;
+
+    captureEvent(ANALYTICS_EVENTS.CHECKOUT_INITIATED, {
+      product_id: 42,
+      value: 14,
+      currency: "USD",
+    });
+
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+    expect(posthog.capture).toHaveBeenCalledWith("checkout_initiated", {
+      product_id: 42,
+      value: 14,
+      currency: "USD",
+    });
+  });
+
+  it("swallows capture errors so the user-facing flow isn't broken", () => {
+    (posthog as unknown as { __loaded: boolean }).__loaded = true;
+    vi.mocked(posthog.capture).mockImplementationOnce(() => {
+      throw new Error("network blocked");
+    });
+
+    expect(() =>
+      captureEvent(ANALYTICS_EVENTS.PURCHASE_COMPLETED, {}),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Implements priority-1 funnel events, priority-2.3 engagement events, and priority-3.2 config cleanup from the audit referenced in #59.

## Events implemented

| Event | Trigger | File |
|---|---|---|
| `checkout_initiated` | PurchaseButton click | `src/components/PurchaseButton.tsx` |
| `purchase_completed` | `/purchase/success` mount | `src/components/PurchaseSuccessTracker.tsx` |
| `purchase_completed_server` | Stripe webhook `checkout.session.completed` | `src/app/api/webhooks/stripe/route.ts` |
| `artwork_viewed` | Artwork detail page mount | `src/components/ArtworkViewedTracker.tsx` |
| `contact_form_submitted` | `submitContactForm` server action | `src/actions/contact.ts` |

## Architecture

- `src/lib/analytics.ts` — event constants + client capture helper
- `src/lib/analytics-server.ts` — server capture helper
- 4 unit tests in `tests/unit/analytics.test.ts`

## Audit task coverage

- [x] 1.1 — Purchase funnel events
- [x] 2.3 — Engagement events (artwork views, contact submissions)
- [x] 3.2 — `instrumentation-client.ts` config cleanup
- [ ] 1.2 — GA4 install (separate PR — needs property + secret)
- [ ] 1.3 — OG metadata (sibling work in progress, see #62)
- [ ] 2.1 — JSON-LD (separate PR)
- [ ] 2.2 — robots.txt (separate PR)
- [ ] 2.4 — KPI dashboards (separate PR)
- [ ] 3.1 — Meta Pixel (separate PR)

Partial-close on #59 (the listed unchecked items remain open under the same audit).

## Quality gates

- typecheck: clean
- lint: clean (no new warnings)
- unit tests: 4/4 pass
- build: succeeds

## Test plan

- [ ] Verify PostHog events fire in `npm run dev` for each trigger
- [ ] Trigger Stripe test webhook → confirm `purchase_completed_server` fires
- [ ] CI green