### PR TITLE
fix(store): keyboard a11y, motion respect, animation consistency

### DIFF
--- a/e2e/store-hover.spec.ts
+++ b/e2e/store-hover.spec.ts
@@ -1,59 +1,106 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.describe('Store Page Hover Description', () => {
+/**
+ * E2E coverage for the store product card hover overlay.
+ *
+ * Requirement traceability (see EONMUN/EONMUN#71):
+ *   Req 2 — Animation consistency: overlay opacity transitions on hover
+ *   Req 3 — Keyboard accessibility: overlay reveals on focus-within
+ *   Req 4 — Screen-reader semantics: name announced once
+ *   Req 5 — Reduced-motion respect: instant transition under reduce
+ */
+
+const OVERLAY = ".bg-gradient-to-t";
+
+test.describe("Store Page Hover Description", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/store');
-    await page.waitForLoadState('networkidle');
+    await page.goto("/store");
+    await page.waitForLoadState("networkidle");
   });
 
-  test('should show description overlay on product hover', async ({ page }) => {
-    // Check that products are loaded
+  test("Req 2: should show description overlay on product hover", async ({
+    page,
+  }) => {
     const productCard = page.locator('[data-testid="product-card"]').first();
     await expect(productCard).toBeVisible();
-    
-    // Hover over the product card to trigger the overlay
+
+    const overlay = productCard.locator(OVERLAY);
+    // Red state pre-implementation: overlay starts hidden, transitions to opaque on hover.
+    await expect(overlay).toHaveCSS("opacity", "0");
+
     await productCard.hover();
-    
-    // The overlay should become visible - check for the title in the overlay
-    const overlayTitle = productCard.locator('h3.text-white');
-    await expect(overlayTitle).toBeVisible({ timeout: 2000 });
+
+    await expect(overlay).toHaveCSS("opacity", "1", { timeout: 2000 });
   });
 
-  test('should display product description in overlay if available', async ({ page }) => {
+  test("Req 3: should reveal overlay when product link receives keyboard focus", async ({
+    page,
+  }) => {
+    const productCard = page.locator('[data-testid="product-card"]').first();
+    await expect(productCard).toBeVisible();
+
+    const overlay = productCard.locator(OVERLAY);
+    await expect(overlay).toHaveCSS("opacity", "0");
+
+    // Focus the first link inside the card (simulates Tab landing on card link).
+    // Red state: master code has no group-focus-within, so opacity stays at 0 even with focus.
+    const cardLink = productCard.locator("a").first();
+    await cardLink.focus();
+
+    await expect(overlay).toHaveCSS("opacity", "1", { timeout: 2000 });
+  });
+
+  test("Req 4: overlay h3 must be aria-hidden so screen readers do not double-announce name", async ({
+    page,
+  }) => {
+    const productCard = page.locator('[data-testid="product-card"]').first();
+    await expect(productCard).toBeVisible();
+
+    // Red state pre-implementation: overlay h3 lacks aria-hidden — every product name is in
+    // the accessible tree twice (overlay + card body).
+    const overlayHeading = productCard.locator(OVERLAY).locator("h3");
+    await expect(overlayHeading).toHaveAttribute("aria-hidden", "true");
+  });
+
+  test("Req 2: should display product description in overlay if available", async ({
+    page,
+  }) => {
     const productCards = page.locator('[data-testid="product-card"]');
     const productCount = await productCards.count();
-    
+
     // Try to find a product with a description
     for (let i = 0; i < productCount; i++) {
       const productCard = productCards.nth(i);
       await productCard.hover();
-      
-      // Check if description text exists in the overlay
-      const description = productCard.locator('.text-gray-300.line-clamp-2');
-      if (await description.count() > 0) {
+
+      // Description sits in the overlay container; line-clamp-2 is unique to the description paragraph.
+      const description = productCard.locator(OVERLAY).locator(".line-clamp-2");
+      if ((await description.count()) > 0) {
         await expect(description).toBeVisible({ timeout: 2000 });
         const descText = await description.textContent();
         expect(descText).toBeTruthy();
         expect(descText!.length).toBeGreaterThan(0);
-        break; // Found one, test passes
+        break;
       }
     }
   });
 
-  test('should show year in overlay if available', async ({ page }) => {
+  test("Req 2: should show year in overlay if available", async ({ page }) => {
     const productCards = page.locator('[data-testid="product-card"]');
     const firstProduct = productCards.first();
-    
+
     await firstProduct.hover();
-    
-    // Check if year is displayed (might not be present on all products)
-    const yearText = firstProduct.locator('.text-gray-300.text-sm').first();
+
+    // Year paragraph: scoped to overlay to avoid colliding with the always-visible card body.
+    const yearText = firstProduct
+      .locator(OVERLAY)
+      .locator("p.text-gray-300.text-sm")
+      .first();
     const yearCount = await yearText.count();
-    
+
     if (yearCount > 0) {
       await expect(yearText).toBeVisible({ timeout: 2000 });
       const year = await yearText.textContent();
-      // Year should be a 4-digit number if present
       if (year && year.match(/\d{4}/)) {
         expect(year).toMatch(/\d{4}/);
       }

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -1,19 +1,19 @@
-import { Metadata } from 'next';
-import Link from 'next/link';
-import Image from '@/components/Image';
-import { getAvailableProductsWithArtwork } from '@/actions/product';
-import { getAllCollections } from '@/actions/collection';
-import { PurchaseButton } from '@/components/PurchaseButton';
-import { FrostedGlass } from '@/components/ui/FrostedGlass';
-import type { ProductWithArtwork } from '@/models/product';
+import { Metadata } from "next";
+import Link from "next/link";
+import Image from "@/components/Image";
+import { getAvailableProductsWithArtwork } from "@/actions/product";
+import { getAllCollections } from "@/actions/collection";
+import { PurchaseButton } from "@/components/PurchaseButton";
+import { FrostedGlass } from "@/components/ui/FrostedGlass";
+import type { ProductWithArtwork } from "@/models/product";
 
 export const metadata: Metadata = {
-  title: 'Shop | EONMUN',
-  description: 'Shop original artworks by EONMUN.',
+  title: "Shop | EONMUN",
+  description: "Shop original artworks by EONMUN.",
 };
 
 // Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 function ProductCard({ product }: { product: ProductWithArtwork }) {
   const priceInDollars = product.price / 100;
@@ -21,17 +21,26 @@ function ProductCard({ product }: { product: ProductWithArtwork }) {
   const description = product.description || product.artwork?.description;
 
   return (
-    <div 
+    <div
       className="group bg-surface border border-outline rounded-lg overflow-hidden hover:shadow-lg transition-shadow"
       data-testid="product-card"
     >
-      <Link href={`/store/${product.slug}`}>
+      {/*
+       * CRITICAL: The always-visible card body below carries the accessible product name,
+       * year, and price. The hover/focus overlay is supplementary reinforcement only —
+       * removing the body fields would break touch users (no hover surface) and screen
+       * readers (overlay h3 is aria-hidden to avoid double announcement). See issue #71.
+       */}
+      <Link
+        href={`/store/${product.slug}`}
+        className="block focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 rounded-lg"
+      >
         <div className="relative aspect-square overflow-hidden bg-surface-variant">
           {imageUrl ? (
             <Image
               src={imageUrl}
               alt={product.name}
-              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+              className="w-full h-full object-cover motion-safe:group-hover:scale-105 motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out"
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center text-on-surface-variant">
@@ -39,15 +48,20 @@ function ProductCard({ product }: { product: ProductWithArtwork }) {
             </div>
           )}
 
-          {/* Description overlay on hover */}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
+          {/* Description overlay on hover/focus. Symmetric duration+easing matches the image transform. */}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-out">
             <div className="absolute bottom-4 left-4 right-4">
               <FrostedGlass variant="dark" className="p-3 rounded-lg">
-                <h3 className="text-white font-medium text-lg">
+                <h3
+                  aria-hidden="true"
+                  className="text-white font-medium text-lg"
+                >
                   {product.name}
                 </h3>
                 {product.artwork?.year && (
-                  <p className="text-gray-300 text-sm">{product.artwork.year}</p>
+                  <p className="text-gray-300 text-sm">
+                    {product.artwork.year}
+                  </p>
                 )}
                 {description && (
                   <p className="text-gray-300 text-sm mt-2 line-clamp-2">
@@ -66,24 +80,29 @@ function ProductCard({ product }: { product: ProductWithArtwork }) {
             {product.name}
           </h3>
           {product.artwork?.year && (
-            <p className="text-sm text-on-surface-variant">{product.artwork.year}</p>
+            <p className="text-sm text-on-surface-variant">
+              {product.artwork.year}
+            </p>
           )}
         </Link>
 
         <div className="flex items-center justify-between">
-          <span className="text-xl font-bold text-primary" data-testid="product-price">
+          <span
+            className="text-xl font-bold text-primary"
+            data-testid="product-price"
+          >
             ${priceInDollars.toLocaleString()}
           </span>
         </div>
 
-        <PurchaseButton 
+        <PurchaseButton
           product={{
             id: product.id,
             name: product.name,
             slug: product.slug,
             price: product.price,
-          }} 
-          variant="compact" 
+          }}
+          variant="compact"
         />
       </div>
     </div>
@@ -91,7 +110,9 @@ function ProductCard({ product }: { product: ProductWithArtwork }) {
 }
 
 export default async function StorePage() {
-  const { data: products } = await getAvailableProductsWithArtwork({ type: 'artwork' });
+  const { data: products } = await getAvailableProductsWithArtwork({
+    type: "artwork",
+  });
   const { data: collections } = await getAllCollections();
 
   return (
@@ -110,10 +131,7 @@ export default async function StorePage() {
             <h2 className="font-semibold text-on-surface mb-4">Collections</h2>
             <ul className="space-y-2">
               <li>
-                <Link
-                  href="/store"
-                  className="text-primary hover:underline"
-                >
+                <Link href="/store" className="text-primary hover:underline">
                   All Products
                 </Link>
               </li>


### PR DESCRIPTION
## Summary

Closes #71. Replaces stale draft #47 (which had unrelated `.claude/` churn).

Lands the store product card overlay a11y / motion / animation fixes on a clean branch off `master`.

- Req 2 — Animation consistency: explicit `duration-300` + `ease-out` on the overlay so enter/exit match the image scale.
- Req 3 — Keyboard reveal: `group-focus-within:opacity-100` reveals the overlay when the card link is Tab-focused, plus a visible `focus-visible` ring.
- Req 4 — Screen-reader semantics: `aria-hidden="true"` on the overlay h3 so the product name is not announced twice (the always-visible body h3 and the image `alt` already carry it).
- Req 5 — Reduced-motion respect: all transitions are scoped under Tailwind v4's `motion-safe:` variant; `prefers-reduced-motion: reduce` gets an instant state change.
- Req 6 — Touch surface: comment added documenting why the always-visible card body must remain (touch users have no hover surface).

## Tasks

- [x] Implement overlay a11y/motion/animation fixes in `src/app/store/page.tsx`
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (only pre-existing warnings on unrelated files)
- [x] Commit with conventional message
- [x] Push branch
- [ ] CI green (Playwright e2e specs from #71's red commit `a9c9d9d` should now pass)
- [ ] Manual keyboard nav check on `/store` (deferred: no local Docker / DB available in sandbox; CI will exercise)
- [ ] Mark ready-for-review (kept draft until CI is green)

## Test plan

The failing specs from `e2e/store-hover.spec.ts` (committed in `a9c9d9d` on this branch) are the green contract:

- [ ] `Req 2: should show description overlay on product hover` — passes (overlay still uses `group-hover:opacity-100`)
- [ ] `Req 3: should reveal overlay when product link receives keyboard focus` — passes (added `group-focus-within:opacity-100`)
- [ ] `Req 4: overlay h3 must be aria-hidden so screen readers do not double-announce name` — passes (added `aria-hidden="true"`)
- [ ] `Req 2: should display product description in overlay if available` — passes (overlay opacity transitions on hover)
- [ ] `Req 2: should show year in overlay if available` — passes (year paragraph still rendered in overlay)

## Notes for reviewer

- Reduced motion (Req 5) and touch-surface (Req 6) checks are not covered by Playwright in the existing spec; they are validated by code-review and manual axe / SR checks per the issue's test matrix.
- Pre-existing unit-test failures in `tests/integration/artworks` and `tests/integration/collections` are unrelated (missing `@/database/factories/*` modules on master) and out of scope per #71's Out-of-Scope section.

Refs: #71. Supersedes draft #47.