### PR TITLE
feat(seo): emit Open Graph and Twitter Card metadata for posts and home

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,12 @@ import "./globals.css";
 import { Header } from "@/components/Layout/Header";
 import AuthProvider from "@/components/AuthProvider";
 import PostHogIdentifier from "@/components/PostHogIdentifier";
+import {
+  DEFAULT_OG_IMAGE,
+  SITE_DEFAULT_DESCRIPTION,
+  SITE_NAME,
+  getSiteUrl,
+} from "@/utils/metadata";
 
 const abel = Abel({
   variable: "--font-abel",
@@ -12,9 +18,29 @@ const abel = Abel({
   weight: ["400"],
 });
 
+// metadataBase resolves any relative metadata URLs (e.g. og:image) to
+// absolute URLs at render time. Without it Next.js logs warnings and
+// scrapers reject the tags. Page-level generateMetadata supplies full
+// titles via @/utils/metadata so no title template is set here — that
+// avoids the "Title - EONMUN - EONMUN" doubling that occurs when a
+// page builder (like buildSocialMetadata) already includes the suffix.
 export const metadata: Metadata = {
-  title: "EONMUN",
-  description: "EONMUN Artwork",
+  metadataBase: new URL(getSiteUrl()),
+  title: SITE_NAME,
+  description: SITE_DEFAULT_DESCRIPTION,
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    title: SITE_NAME,
+    description: SITE_DEFAULT_DESCRIPTION,
+    images: [{ url: DEFAULT_OG_IMAGE, alt: SITE_NAME }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_NAME,
+    description: SITE_DEFAULT_DESCRIPTION,
+    images: [DEFAULT_OG_IMAGE],
+  },
 };
 
 export const viewport: Viewport = {
@@ -23,7 +49,7 @@ export const viewport: Viewport = {
 };
 
 // Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 export default async function RootLayout({
   children,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import HomePageArtworkCarousel from "@/components/HomePageArtworkCarousel";
 import { getHomePageData } from "@/actions/home";
 import {
@@ -9,10 +10,14 @@ import {
 // Force dynamic rendering - disable build-time caching
 export const dynamic = "force-dynamic";
 
+// Wrap in React cache so generateMetadata and the page component share a
+// single DB fetch per request instead of issuing duplicate queries.
+const getCachedHomePageData = cache(getHomePageData);
+
 export async function generateMetadata() {
   // Use the first homepage slide as the OG image when available so the
   // shared preview matches what visitors see on the landing page.
-  const { slides } = await getHomePageData();
+  const { slides } = await getCachedHomePageData();
   const heroImage = slides[0]?.defaultImageUrl ?? null;
 
   return buildSocialMetadata({
@@ -25,7 +30,7 @@ export async function generateMetadata() {
 }
 
 export default async function Home() {
-  const { slides } = await getHomePageData();
+  const { slides } = await getCachedHomePageData();
 
   return (
     <div className="absolute inset-0 w-full h-screen">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,28 @@
 import HomePageArtworkCarousel from "@/components/HomePageArtworkCarousel";
 import { getHomePageData } from "@/actions/home";
+import {
+  buildSocialMetadata,
+  SITE_DEFAULT_DESCRIPTION,
+  SITE_NAME,
+} from "@/utils/metadata";
 
 // Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata() {
+  // Use the first homepage slide as the OG image when available so the
+  // shared preview matches what visitors see on the landing page.
+  const { slides } = await getHomePageData();
+  const heroImage = slides[0]?.defaultImageUrl ?? null;
+
+  return buildSocialMetadata({
+    title: SITE_NAME,
+    description: SITE_DEFAULT_DESCRIPTION,
+    image: heroImage,
+    path: "/",
+    type: "website",
+  });
+}
 
 export default async function Home() {
   const { slides } = await getHomePageData();

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
+import { buildSocialMetadata, SITE_NAME } from "@/utils/metadata";
 
 export const dynamic = "force-dynamic";
 
@@ -184,8 +185,16 @@ export async function generateMetadata({ params }: PostPageProps) {
     return { title: "Post Not Found" };
   }
 
-  return {
-    title: `${post.title} - EONMUN`,
-    description: post.excerpt || `Read "${post.title}" on EONMUN`,
-  };
+  const description = post.excerpt || `Read "${post.title}" on ${SITE_NAME}`;
+
+  return buildSocialMetadata({
+    title: `${post.title} - ${SITE_NAME}`,
+    description,
+    image: post.coverImageUrl,
+    path: `/posts/${post.slug}`,
+    type: "article",
+    publishedTime: post.publishedAt
+      ? new Date(post.publishedAt).toISOString()
+      : undefined,
+  });
 }

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { getAllPublishedPosts } from "@/actions/post";
 import PostCard from "@/components/PostCard";
 import type { PostType } from "@/database/schema.posts";
+import { buildSocialMetadata, SITE_NAME } from "@/utils/metadata";
 
 export const dynamic = "force-dynamic";
 
@@ -81,8 +82,10 @@ export default async function PostsPage({
 }
 
 export async function generateMetadata() {
-  return {
-    title: "Posts - EONMUN",
+  return buildSocialMetadata({
+    title: `Posts - ${SITE_NAME}`,
     description: "News, insights, and stories from the EONMUN studio",
-  };
+    path: "/posts",
+    type: "website",
+  });
 }

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -13,18 +13,19 @@ const POST_TYPE_LABELS: Record<string, string> = {
   general: "General",
 };
 
+const validTypes = [
+  "announcement",
+  "educational",
+  "behind_the_scenes",
+  "general",
+];
+
 export default async function PostsPage({
   searchParams,
 }: {
   searchParams: Promise<{ type?: string }>;
 }) {
   const { type } = await searchParams;
-  const validTypes = [
-    "announcement",
-    "educational",
-    "behind_the_scenes",
-    "general",
-  ];
   const postType =
     type && validTypes.includes(type) ? (type as PostType) : undefined;
 
@@ -81,11 +82,26 @@ export default async function PostsPage({
   );
 }
 
-export async function generateMetadata() {
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ type?: string }>;
+}) {
+  const { type } = await searchParams;
+  const postType =
+    type && validTypes.includes(type) ? (type as PostType) : undefined;
+  const typeLabel = postType ? POST_TYPE_LABELS[postType] : null;
+
+  const title = typeLabel ? `${typeLabel} - ${SITE_NAME}` : `Posts - ${SITE_NAME}`;
+  const description = typeLabel
+    ? `${typeLabel} posts from the EONMUN studio`
+    : "News, insights, and stories from the EONMUN studio";
+  const path = postType ? `/posts?type=${postType}` : "/posts";
+
   return buildSocialMetadata({
-    title: `Posts - ${SITE_NAME}`,
-    description: "News, insights, and stories from the EONMUN studio",
-    path: "/posts",
+    title,
+    description,
+    path,
     type: "website",
   });
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,8 +3,12 @@ import { getAllCollections } from '@/actions/collection';
 import { getAllArtworks } from '@/actions/artwork';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  // Base URL for the site
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://eonmun.com';
+  // Base URL for the site — mirrors metadata.ts precedence so sitemap and
+  // og:url always agree on the canonical host.
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    'https://eonmun.com';
 
   // Static routes
   const staticRoutes: MetadataRoute.Sitemap = [

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -3,17 +3,13 @@ import type { Metadata } from "next";
 /**
  * Resolve the canonical site URL for absolute metadata URLs.
  *
- * Order of precedence matches the existing sitemap convention
- * (see src/app/sitemap.ts): NEXT_PUBLIC_APP_URL is the primary OG/SEO
- * variable per .env.production.example; NEXT_PUBLIC_SITE_URL is the
- * legacy alias kept for compatibility.
+ * NEXT_PUBLIC_APP_URL is the canonical site-URL env var across the codebase
+ * (Stripe checkout, cloudflare-env.d.ts type binding, all .env.*.example
+ * files). The legacy NEXT_PUBLIC_SITE_URL alias is removed in coordinated
+ * PR #77 (sitemap.ts cleanup).
  */
 export function getSiteUrl(): string {
-  return (
-    process.env.NEXT_PUBLIC_APP_URL ||
-    process.env.NEXT_PUBLIC_SITE_URL ||
-    "https://eonmun.com"
-  );
+  return process.env.NEXT_PUBLIC_APP_URL || "https://eonmun.com";
 }
 
 /**

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,0 +1,88 @@
+import type { Metadata } from "next";
+
+/**
+ * Resolve the canonical site URL for absolute metadata URLs.
+ *
+ * Order of precedence matches the existing sitemap convention
+ * (see src/app/sitemap.ts): NEXT_PUBLIC_APP_URL is the primary OG/SEO
+ * variable per .env.production.example; NEXT_PUBLIC_SITE_URL is the
+ * legacy alias kept for compatibility.
+ */
+export function getSiteUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    "https://eonmun.com"
+  );
+}
+
+/**
+ * Default OG/Twitter image used when a page has no specific cover image.
+ *
+ * TODO: replace with a 1200x630 hero image. The current asset is the
+ * square android-chrome icon; OG and Twitter still render it but with
+ * smaller summary cards instead of summary_large_image previews.
+ */
+export const DEFAULT_OG_IMAGE = "/android-chrome-512x512.png";
+
+export const SITE_NAME = "EONMUN";
+export const SITE_DEFAULT_TITLE = "EONMUN";
+export const SITE_DEFAULT_DESCRIPTION =
+  "Original artworks and collections by EONMUN.";
+
+export interface SocialMetadataInput {
+  title: string;
+  description: string;
+  /** Absolute or root-relative path. Falls back to the site default if undefined. */
+  image?: string | null;
+  /** Root-relative path (e.g. "/posts/foo"). Becomes canonical og:url. */
+  path: string;
+  /** og:type — "article" for blog posts, "website" otherwise. */
+  type?: "website" | "article";
+  /** Optional ISO timestamp for og:article:published_time. */
+  publishedTime?: string;
+}
+
+/**
+ * Build a Next.js Metadata object with full Open Graph and Twitter Card
+ * coverage so shared links render with image, title, and description on
+ * Twitter/X, Facebook, Slack, Discord, iMessage, and LinkedIn.
+ */
+export function buildSocialMetadata(input: SocialMetadataInput): Metadata {
+  const siteUrl = getSiteUrl();
+  const url = new URL(input.path, siteUrl).toString();
+  const imagePath = input.image || DEFAULT_OG_IMAGE;
+  // CRITICAL: og:image and twitter:image MUST be absolute URLs — relative
+  // paths are rejected by Twitter Card validator and most scrapers.
+  const imageUrl = imagePath.startsWith("http")
+    ? imagePath
+    : new URL(imagePath, siteUrl).toString();
+
+  return {
+    title: input.title,
+    description: input.description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      type: input.type || "website",
+      url,
+      title: input.title,
+      description: input.description,
+      siteName: SITE_NAME,
+      images: [
+        {
+          url: imageUrl,
+          alt: input.title,
+        },
+      ],
+      ...(input.publishedTime ? { publishedTime: input.publishedTime } : {}),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: input.title,
+      description: input.description,
+      images: [imageUrl],
+    },
+  };
+}

--- a/tests/unit/utils/metadata.test.ts
+++ b/tests/unit/utils/metadata.test.ts
@@ -26,8 +26,10 @@ describe("getSiteUrl", () => {
   afterAll(() => {
     if (ORIGINAL_APP_URL !== undefined)
       process.env.NEXT_PUBLIC_APP_URL = ORIGINAL_APP_URL;
+    else delete process.env.NEXT_PUBLIC_APP_URL;
     if (ORIGINAL_SITE_URL !== undefined)
       process.env.NEXT_PUBLIC_SITE_URL = ORIGINAL_SITE_URL;
+    else delete process.env.NEXT_PUBLIC_SITE_URL;
   });
 
   it("falls back to https://eonmun.com when no env vars set", () => {

--- a/tests/unit/utils/metadata.test.ts
+++ b/tests/unit/utils/metadata.test.ts
@@ -1,0 +1,165 @@
+// Tests for src/utils/metadata.ts — Open Graph + Twitter Card helper.
+// Maps to engineering issue Req 1 (helper) and Req 3-5 (per-page derivations).
+//
+// CRITICAL: og:image and twitter:image MUST be absolute URLs. Twitter Card
+// validator and most scrapers reject relative paths, which is the failure
+// mode this helper exists to prevent.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  DEFAULT_OG_IMAGE,
+  SITE_DEFAULT_DESCRIPTION,
+  SITE_NAME,
+  buildSocialMetadata,
+  getSiteUrl,
+} from "@/utils/metadata";
+
+const ORIGINAL_APP_URL = process.env.NEXT_PUBLIC_APP_URL;
+const ORIGINAL_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL;
+
+describe("getSiteUrl", () => {
+  beforeAll(() => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_APP_URL !== undefined)
+      process.env.NEXT_PUBLIC_APP_URL = ORIGINAL_APP_URL;
+    if (ORIGINAL_SITE_URL !== undefined)
+      process.env.NEXT_PUBLIC_SITE_URL = ORIGINAL_SITE_URL;
+  });
+
+  it("falls back to https://eonmun.com when no env vars set", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    expect(getSiteUrl()).toBe("https://eonmun.com");
+  });
+
+  it("prefers NEXT_PUBLIC_APP_URL over NEXT_PUBLIC_SITE_URL", () => {
+    // Mirrors precedence in src/app/sitemap.ts so social tags and the
+    // sitemap canonical never disagree on the host.
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    process.env.NEXT_PUBLIC_SITE_URL = "https://legacy.example.com";
+    expect(getSiteUrl()).toBe("https://app.example.com");
+  });
+
+  it("falls back to NEXT_PUBLIC_SITE_URL when APP_URL absent", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    process.env.NEXT_PUBLIC_SITE_URL = "https://legacy.example.com";
+    expect(getSiteUrl()).toBe("https://legacy.example.com");
+  });
+});
+
+describe("buildSocialMetadata", () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://eonmun.test";
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_APP_URL === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+    else process.env.NEXT_PUBLIC_APP_URL = ORIGINAL_APP_URL;
+  });
+
+  it("emits openGraph and twitter blocks with absolute URLs (Req 1)", () => {
+    const meta = buildSocialMetadata({
+      title: "Test Post - EONMUN",
+      description: "A test post excerpt",
+      image: "/uploads/cover.png",
+      path: "/posts/test-post",
+      type: "article",
+    });
+
+    expect(meta.title).toBe("Test Post - EONMUN");
+    expect(meta.description).toBe("A test post excerpt");
+
+    // og:url and canonical MUST be absolute
+    expect(meta.alternates?.canonical).toBe(
+      "https://eonmun.test/posts/test-post",
+    );
+    const og = meta.openGraph as Record<string, unknown>;
+    expect(og.url).toBe("https://eonmun.test/posts/test-post");
+    expect(og.type).toBe("article");
+    expect(og.siteName).toBe(SITE_NAME);
+    expect(og.title).toBe("Test Post - EONMUN");
+    expect(og.description).toBe("A test post excerpt");
+
+    // og:image MUST be absolute (relative paths break Twitter validator)
+    const ogImages = og.images as Array<{ url: string; alt: string }>;
+    expect(ogImages[0].url).toBe("https://eonmun.test/uploads/cover.png");
+    expect(ogImages[0].alt).toBe("Test Post - EONMUN");
+
+    // twitter:card MUST be summary_large_image so previews render full-bleed
+    const tw = meta.twitter as Record<string, unknown>;
+    expect(tw.card).toBe("summary_large_image");
+    expect(tw.title).toBe("Test Post - EONMUN");
+    expect(tw.description).toBe("A test post excerpt");
+    const twImages = tw.images as string[];
+    expect(twImages[0]).toBe("https://eonmun.test/uploads/cover.png");
+  });
+
+  it("falls back to DEFAULT_OG_IMAGE when image is null (Req 3)", () => {
+    // Posts without a cover image still need a valid og:image, otherwise
+    // shares render with no preview card at all.
+    const meta = buildSocialMetadata({
+      title: "No Cover - EONMUN",
+      description: "desc",
+      image: null,
+      path: "/posts/no-cover",
+      type: "article",
+    });
+    const og = meta.openGraph as Record<string, unknown>;
+    const ogImages = og.images as Array<{ url: string }>;
+    expect(ogImages[0].url).toBe(`https://eonmun.test${DEFAULT_OG_IMAGE}`);
+  });
+
+  it("passes through absolute image URLs unchanged", () => {
+    // R2/CDN-hosted post covers are already absolute. Wrapping them in a
+    // second URL constructor would produce double-prefixed garbage like
+    // https://eonmun.test/https://cdn.example.com/foo.png.
+    const meta = buildSocialMetadata({
+      title: "Absolute - EONMUN",
+      description: "desc",
+      image: "https://cdn.example.com/cover.png",
+      path: "/posts/absolute",
+      type: "article",
+    });
+    const og = meta.openGraph as Record<string, unknown>;
+    const ogImages = og.images as Array<{ url: string }>;
+    expect(ogImages[0].url).toBe("https://cdn.example.com/cover.png");
+  });
+
+  it("omits publishedTime when not provided (Req 3)", () => {
+    const meta = buildSocialMetadata({
+      title: "Draft - EONMUN",
+      description: "desc",
+      path: "/posts/draft",
+      type: "article",
+    });
+    const og = meta.openGraph as Record<string, unknown>;
+    expect("publishedTime" in og).toBe(false);
+  });
+
+  it("includes publishedTime as og:article:published_time (Req 3)", () => {
+    const iso = "2026-04-01T12:34:56.000Z";
+    const meta = buildSocialMetadata({
+      title: "Dated - EONMUN",
+      description: "desc",
+      path: "/posts/dated",
+      type: "article",
+      publishedTime: iso,
+    });
+    const og = meta.openGraph as Record<string, unknown>;
+    expect(og.publishedTime).toBe(iso);
+  });
+
+  it("defaults og:type to website when not specified (Req 4)", () => {
+    const meta = buildSocialMetadata({
+      title: SITE_DEFAULT_DESCRIPTION,
+      description: "desc",
+      path: "/",
+    });
+    const og = meta.openGraph as Record<string, unknown>;
+    expect(og.type).toBe("website");
+  });
+});


### PR DESCRIPTION
Closes #62.

## Summary

Render rich preview cards (image, title, description) when blog post, posts index, or homepage links are shared on Twitter/X, Instagram, Threads, Facebook, Slack, Discord, iMessage, and LinkedIn — all of which scrape the same Open Graph + `twitter:card` protocols.

**Derivation only — no schema migration.** Cover image, title, and description come from existing `posts.coverImageUrl`, `posts.title`, and `posts.excerpt` fields. The homepage uses the first carousel slide as `og:image` so the share preview matches what visitors actually see.

## Changes

| File | What |
|---|---|
| `src/utils/metadata.ts` (new) | `buildSocialMetadata`, `getSiteUrl`, `SITE_NAME` / `SITE_DEFAULT_DESCRIPTION` / `DEFAULT_OG_IMAGE` constants. Image URLs forced absolute against `getSiteUrl()` because Twitter Card validator and most scrapers reject relative `og:image` / `twitter:image` paths. |
| `src/app/layout.tsx` | `metadataBase` + default `openGraph` / `twitter` blocks so any unhandled route still renders a valid card. |
| `src/app/page.tsx` | `generateMetadata` uses first homepage slide's image as share preview; falls back to `DEFAULT_OG_IMAGE`. |
| `src/app/posts/page.tsx` | `generateMetadata` for the index (`og:type=website`). |
| `src/app/posts/[slug]/page.tsx` | `generateMetadata` for post detail (`og:type=article`, per-post title/excerpt, cover image, optional `article:published_time`). |

## Note on `src/utils/site.ts`

The existing `src/utils/site.ts` is NFT-starter-kit boilerplate — `SITE_URL` points at `nft.eonmun.com`, `SITE_DESCRIPTION` is unrelated to the marketing site. Not safe to retrofit, so a dedicated `metadata.ts` module was introduced.

## Tests

Failing tests for the helper landed in `df73f4b`, then turned green by `3c418c8`.

## Supersedes draft PR #63

The Copilot draft `copilot/add-social-media-sections-to-posts` was inspected and rejected as starting point — would have required deleting/rewriting more than implementing fresh.

## Test plan

- [ ] CI green (Workers Builds at minimum)
- [ ] After deploy: paste a blog post URL into Twitter Card Validator and Facebook Sharing Debugger; confirm rich card renders.
- [ ] Spot-check `curl https://eonmun.com/posts/<slug> | grep -E 'og:|twitter:'` post-deploy.