### PR TITLE
feat(seo): expand sitemap with /contact, /store, /posts and detail pages

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,69 +1,116 @@
-import { MetadataRoute } from 'next';
-import { getAllCollections } from '@/actions/collection';
-import { getAllArtworks } from '@/actions/artwork';
+import { MetadataRoute } from "next";
+import { getAllCollections } from "@/actions/collection";
+import { getAllArtworks } from "@/actions/artwork";
+import { getAllPublishedPosts } from "@/actions/post";
+import { getAvailableProducts } from "@/actions/product";
+
+// SEO sitemap. Includes every public, indexable URL on the marketing site.
+// Excludes /admin, /purchase, /nfts, /auth, and any non-public routes.
+// Falls back to static routes only if any DB call fails — better an incomplete
+// sitemap than a 500 that drops us out of search-engine indexes entirely.
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  // Base URL for the site
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://eonmun.com';
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://eonmun.com";
 
-  // Static routes
   const staticRoutes: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
       lastModified: new Date(),
-      changeFrequency: 'daily',
+      changeFrequency: "daily",
       priority: 1,
     },
     {
       url: `${baseUrl}/about`,
       lastModified: new Date(),
-      changeFrequency: 'monthly',
+      changeFrequency: "monthly",
       priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/contact`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.5,
     },
     {
       url: `${baseUrl}/collections`,
       lastModified: new Date(),
-      changeFrequency: 'weekly',
+      changeFrequency: "weekly",
       priority: 0.9,
     },
     {
       url: `${baseUrl}/artworks`,
       lastModified: new Date(),
-      changeFrequency: 'weekly',
+      changeFrequency: "weekly",
       priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/store`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/posts`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
     },
   ];
 
   try {
-    // Fetch all collections
-    const collectionsResponse = await getAllCollections();
-    const collections = collectionsResponse.data;
+    // Both calls default to published=true, but pass explicitly so future
+    // changes to action defaults can't silently leak drafts into the sitemap.
+    const [
+      { data: collections },
+      { data: artworks },
+      { data: posts },
+      { data: products },
+    ] = await Promise.all([
+      getAllCollections({ published: true }),
+      getAllArtworks({ published: true }),
+      getAllPublishedPosts(),
+      getAvailableProducts(),
+    ]);
 
-    // Generate collection routes
-    const collectionRoutes: MetadataRoute.Sitemap = collections.map((collection) => ({
-      url: `${baseUrl}/collections/${collection.slug}`,
-      lastModified: new Date(collection.updatedAt),
-      changeFrequency: 'weekly' as const,
-      priority: 0.8,
-    }));
+    const collectionRoutes: MetadataRoute.Sitemap = collections.map(
+      (collection) => ({
+        url: `${baseUrl}/collections/${collection.slug}`,
+        lastModified: new Date(collection.updatedAt),
+        changeFrequency: "weekly" as const,
+        priority: 0.8,
+      }),
+    );
 
-    // Fetch all artworks
-    const artworksResponse = await getAllArtworks();
-    const artworks = artworksResponse.data;
-
-    // Generate artwork routes
     const artworkRoutes: MetadataRoute.Sitemap = artworks.map((artwork) => ({
       url: `${baseUrl}/artworks/${artwork.slug}`,
       lastModified: new Date(artwork.updatedAt),
-      changeFrequency: 'monthly' as const,
+      changeFrequency: "monthly" as const,
       priority: 0.7,
     }));
 
-    // Combine all routes
-    return [...staticRoutes, ...collectionRoutes, ...artworkRoutes];
+    const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+      url: `${baseUrl}/posts/${post.slug}`,
+      lastModified: new Date(post.updatedAt),
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    }));
+
+    const productRoutes: MetadataRoute.Sitemap = products.map((product) => ({
+      url: `${baseUrl}/store/${product.slug}`,
+      lastModified: new Date(product.updatedAt),
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    }));
+
+    return [
+      ...staticRoutes,
+      ...collectionRoutes,
+      ...artworkRoutes,
+      ...postRoutes,
+      ...productRoutes,
+    ];
   } catch (error) {
-    console.error('Error generating sitemap:', error);
-    // Return only static routes if API fails
+    console.error("Error generating sitemap:", error);
     return staticRoutes;
   }
-} 
+}


### PR DESCRIPTION
Closes #65.

## Baseline (production sitemap, pre-this-PR)

```
  1  /
  1  /about
 16  /artworks (1 index + 15 detail)
  7  /collections (1 index + 6 detail)
```

25 URLs total. Missing: `/contact`, `/store` + product pages, `/posts` + post pages — half the site's indexable surface.

## Changes

- Add `/contact`, `/store`, `/posts` to static routes.
- Query `getAvailableProducts()` and `getAllPublishedPosts()` alongside the existing collections/artworks calls (single `Promise.all`).
- Emit `/store/[slug]` for each available product (not sold, in stock).
- Emit `/posts/[slug]` for each published post.
- Pass `published: true` explicitly to `getAllArtworks` / `getAllCollections` so future changes to action defaults can't silently leak drafts into the sitemap.
- Same `try/catch` fallback as before: if any DB call fails, degrade to static-only routes rather than 500.

## Verification

- `nix develop -c npx tsc --noEmit` — clean
- `nix develop -c npx eslint src/app/sitemap.ts` — clean
- `nix develop -c npx next build` — compiles. The sitemap route's catch-block fired during the build's static analysis phase (no DB connection in the fresh worktree, expected); fallback to static-only worked. In production, the full sitemap will populate.

**Preview verification (after CI):** the user requested verification on a Cloudflare Workers preview build before merging. Once `Workers Builds: eonmun` finishes deploying, fetch `<preview-url>/sitemap.xml` and confirm the URL counts match the local DB row counts.

## Test plan

- [ ] `Workers Builds: eonmun` succeeds
- [ ] `<preview-url>/sitemap.xml` includes `/contact`, `/store`, `/posts`, plus dynamic `/store/<slug>` and `/posts/<slug>` URLs
- [ ] After merge & deploy: `curl https://eonmun.com/sitemap.xml | grep -c '<loc>'` is greater than the current 25
- [ ] Submit updated sitemap to Google Search Console (operational follow-up — out of scope)