### PR TITLE
feat(about): replace stub with real bio + artist statement page

### DIFF
--- a/e2e/about.spec.ts
+++ b/e2e/about.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("About page", () => {
+  test("renders headings, CTAs, and SEO metadata", async ({ page }) => {
+    await page.goto("/about");
+
+    // Hero heading is the site name (matches Navigation/site.ts conventions).
+    await expect(
+      page.getByRole("heading", { level: 1, name: /eonmun/i }),
+    ).toBeVisible();
+
+    // Required structural sections per M2 (bio + artist statement).
+    await expect(
+      page.getByRole("heading", { level: 2, name: /biography/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 2, name: /artist statement/i }),
+    ).toBeVisible();
+
+    // CTAs link to collections and contact.
+    await expect(
+      page.getByRole("link", { name: /view collections/i }),
+    ).toHaveAttribute("href", "/collections");
+    await expect(
+      page.getByRole("link", { name: /^contact$/i }).first(),
+    ).toHaveAttribute("href", "/contact");
+
+    // SEO: og:type=website and absolute og:url for /about.
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute(
+      "content",
+      "website",
+    );
+    const ogUrl = await page
+      .locator('meta[property="og:url"]')
+      .getAttribute("content");
+    expect(ogUrl).toMatch(/\/about$/);
+
+    // twitter:card must be summary_large_image (set by buildSocialMetadata).
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+      "content",
+      "summary_large_image",
+    );
+  });
+});

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,13 +1,119 @@
-// Force dynamic rendering - disable build-time caching
-export const dynamic = 'force-dynamic';
+import Link from "next/link";
+import { buildSocialMetadata, SITE_NAME } from "@/utils/metadata";
+
+// Near-static page: revalidate once a day so a future swap-in of
+// real bio copy (or a DB-backed source) does not require a redeploy.
+// CRITICAL: do not reintroduce `dynamic = "force-dynamic"` here — see PR #72.
+export const revalidate = 86400;
+
+const PAGE_TITLE = `About ${SITE_NAME}`;
+const PAGE_DESCRIPTION =
+  "Biography and artist statement of EONMUN — original artworks and collections.";
 
 export default function AboutPage() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-bold mb-4">About</h1>
-      <p className="text-lg text-gray-600">
-        Page temporarily unavailable. Content will be added from database fixtures.
-      </p>
+    <div className="min-h-screen bg-background text-on-background">
+      <div className="container mx-auto px-4 py-16">
+        <article className="max-w-3xl mx-auto">
+          {/* Hero */}
+          <header className="mb-12 text-center">
+            <h1 className="text-4xl sm:text-5xl font-bold tracking-wide text-on-background mb-4">
+              {SITE_NAME}
+            </h1>
+            {/* TODO(artist): replace tagline with one the artist endorses. */}
+            <p className="text-lg text-on-surface-variant">
+              Original artworks and collections.
+            </p>
+          </header>
+
+          {/* Bio */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold text-on-background mb-4">
+              Biography
+            </h2>
+            <div className="prose prose-lg max-w-none text-on-surface prose-headings:text-on-background prose-strong:text-on-surface space-y-4">
+              {/*
+                TODO(artist): replace placeholder biography below with the
+                artist-approved long-form bio. Keep to 2–3 paragraphs and
+                cover: where the artist is based, formal training (if any),
+                primary mediums, and notable past exhibitions or
+                publications. Do not invent biographical details; ship empty
+                paragraphs rather than fabricated ones.
+              */}
+              <p>
+                Biography coming soon. The full artist biography will appear
+                here, including background, training, and the path that led to
+                the current body of work.
+              </p>
+              <p>
+                In the meantime, the work itself is the most accurate
+                introduction. Browse the{" "}
+                <Link
+                  href="/collections"
+                  className="text-primary hover:underline"
+                >
+                  collections
+                </Link>{" "}
+                or get in touch directly via the{" "}
+                <Link href="/contact" className="text-primary hover:underline">
+                  contact page
+                </Link>
+                .
+              </p>
+            </div>
+          </section>
+
+          {/* Artist statement */}
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold text-on-background mb-4">
+              Artist statement
+            </h2>
+            <div className="prose prose-lg max-w-none text-on-surface prose-headings:text-on-background prose-strong:text-on-surface space-y-4">
+              {/*
+                TODO(artist): replace placeholder statement with the
+                artist's own words. One paragraph in editorial voice. Avoid
+                generic "exploring the intersection of X and Y" filler.
+              */}
+              <p>
+                Artist statement coming soon. This section is reserved for a
+                short, first-person reflection on what the work is about and why
+                it is being made.
+              </p>
+            </div>
+          </section>
+
+          {/* TODO(artist): add an Exhibitions & Press section once the
+              artist provides a verified list. Tracked separately so this
+              first ship does not hold on it. */}
+
+          {/* CTA */}
+          <section className="mt-16 pt-8 border-t border-outline">
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link
+                href="/collections"
+                className="px-6 py-3 bg-primary text-on-primary font-bold tracking-wide rounded-lg hover:opacity-90 transition-opacity text-center"
+              >
+                View collections
+              </Link>
+              <Link
+                href="/contact"
+                className="px-6 py-3 border border-outline text-on-background font-bold tracking-wide rounded-lg hover:bg-surface transition-colors text-center"
+              >
+                Contact
+              </Link>
+            </div>
+          </section>
+        </article>
+      </div>
     </div>
   );
+}
+
+export async function generateMetadata() {
+  return buildSocialMetadata({
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    path: "/about",
+    type: "website",
+  });
 }


### PR DESCRIPTION
Supersedes draft PR #57.

## Why supersede #57

The Copilot draft on `copilot/add-about-page` invents biographical claims about EONMUN ("Eastern and Western traditions", specific media), keeps `force-dynamic`, and doesn't use the new `buildSocialMetadata` helper from PR #76. Reimplemented cleanly off latest master.

## What this ships

| Section | Content |
|---|---|
| Hero | Site name + tagline (TODO for artist to endorse) |
| Biography | 2-paragraph placeholder explicitly marked `TODO(artist)` — instruction: do not invent biographical details, ship empty rather than fabricated |
| Artist Statement | 1-paragraph placeholder, first-person editorial voice (TODO) |
| CTAs | Links to `/collections` and `/contact` |

Comment-only TODO for an Exhibitions & Press section, deferred to a follow-up once the artist provides verified entries.

## Architectural choice

Hardcoded JSX with TODO placeholders. Considered:
- **Post-as-page**: structurally fits but conflicts with `/posts/[slug]` and renders `notFound()` until seeded — worse than static.
- **New `pages` table + admin UI**: too much for one PR.
- **Hardcoded (chosen)**: ships visual treatment now, leaves clean seams for the artist to swap in real copy.

No DB calls; page renders without touching the database.

## Quality gates

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build` — `/about` shows as a route, no errors
- `npx playwright test e2e/about.spec.ts` — **1 passed** (asserts H1, H2 sections, CTA hrefs, og:type=website, canonical og:url ending in /about, twitter:card=summary_large_image)

## Notable changes vs. master

- **Removes** `export const dynamic = 'force-dynamic'` — replaces with `export const revalidate = 86400` (24h ISR) per the M2 / ISR direction.
- **Adds** `generateMetadata` via `buildSocialMetadata` from `src/utils/metadata.ts`.
- **Adds** `e2e/about.spec.ts` smoke test.

## Test plan

- [ ] CI green
- [ ] Visit `/about` on the Workers Build preview; confirm grid + sections render
- [ ] After merge: artist can replace TODO blocks via small follow-up PRs