### PR TITLE
fix(auth): allow second administrator email

### DIFF
--- a/code/wrangler.jsonc
+++ b/code/wrangler.jsonc
@@ -33,7 +33,7 @@
 		{ "pattern": "eonmun.com", "custom_domain": true }
 	],
 	"vars": {
-		"ADMIN_EMAILS": "ncrmro@gmail.com",
+		"ADMIN_EMAILS": "ncrmro@gmail.com,1e1104k4@gmail.com",
 		"R2_PUBLIC_URL": "https://r2.eonmun.com"
 	},
 	// SESSION KV namespace for Astro Sessions on the @astrojs/cloudflare


### PR DESCRIPTION
## Summary

- allow `1e1104k4@gmail.com` to access the Astro administrator routes
- preserve the existing `ncrmro@gmail.com` administrator

## Root cause

The production `ADMIN_EMAILS` Worker variable contained only `ncrmro@gmail.com`, so Auth.js accepted the Google login but the administrator authorization check rejected Leila's account.

## Validation

- `devenv shell -- bun run astro build`
