### PR TITLE
fix(auth): persist Google client ID

### DIFF
--- a/code/wrangler.jsonc
+++ b/code/wrangler.jsonc
@@ -5,10 +5,11 @@
 //   TURSO_DATABASE_URL   — libsql connection URL to the production Turso DB
 //   TURSO_AUTH_TOKEN     — Turso auth token
 //   AUTH_SECRET          — Auth.js JWT/session encryption secret
-//   AUTH_GOOGLE_ID       — Google OAuth client ID for `/api/auth`
 //   AUTH_GOOGLE_SECRET   — Google OAuth client secret for `/api/auth`
 //   STRIPE_SECRET_KEY    — only when `/api/checkout` is implemented (later PR)
 //   CONTACT_EMAIL        — only when `/api/contact` email-sending is wired (later PR)
+//
+// AUTH_GOOGLE_ID is a public OAuth client ID and is configured in `vars` below.
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
 	// Use a dedicated worker so preview URLs can be generated without
@@ -33,6 +34,7 @@
 		{ "pattern": "eonmun.com", "custom_domain": true }
 	],
 	"vars": {
+		"AUTH_GOOGLE_ID": "155891318260-8svnveu1achtgut2oft9pmr31jpmlk2q.apps.googleusercontent.com",
 		"ADMIN_EMAILS": "ncrmro@gmail.com,1e1104k4@gmail.com",
 		"R2_PUBLIC_URL": "https://r2.eonmun.com"
 	},


### PR DESCRIPTION
## Summary

- configure the public Google OAuth client ID in `wrangler.jsonc`
- document that the client ID is a normal Worker variable, not a secret

## Root cause

The client ID was set only on one Cloudflare Worker version. The next automated `wrangler deploy` created a version without that variable, which caused `/api/auth/signin` to return `503`.

## Validation

- `devenv shell -- bun run astro build`
- production was restored with Worker version `5cf48622-a39d-4f3b-a2e9-34cfc5c2574e`
- the live sign-in GET renders the Google provider form
