### PR TITLE
feat(admin): rebuild the console as an image-forward dashboard

### DIFF
--- a/code/src/db/admin.ts
+++ b/code/src/db/admin.ts
@@ -264,9 +264,11 @@ export interface AdminDashboard {
 
 const DASHBOARD_LIMIT = 3;
 
+// sum() over zero rows is NULL in SQLite, and an ungrouped aggregate always
+// returns a row, so every conditional count needs its own coalesce.
 const publishedTally = (column: typeof artworks.publishedAt | typeof collections.publishedAt) => ({
 	total: sql<number>`count(*)`,
-	published: sql<number>`sum(case when ${column} is not null then 1 else 0 end)`,
+	published: sql<number>`coalesce(sum(case when ${column} is not null then 1 else 0 end), 0)`,
 });
 
 // One artwork can carry several images; the dashboard needs exactly one, and it
@@ -278,16 +280,18 @@ function defaultImageOf(images: { url: string; isDefault: boolean }[]) {
 export async function getAdminDashboard(env: Env, db = getDb(env)): Promise<AdminDashboard> {
 	const [artworkRows, collectionRows, productRows, artworkTally, collectionTally, storeTally] =
 		await Promise.all([
-			db.select().from(artworks).orderBy(desc(artworks.createdAt)).limit(DASHBOARD_LIMIT),
-			db.select().from(collections).orderBy(desc(collections.createdAt)).limit(DASHBOARD_LIMIT),
-			db.select().from(products).orderBy(desc(products.createdAt)).limit(DASHBOARD_LIMIT),
+			// created_at holds whole seconds, so rows written in the same second
+			// tie; the autoincrement id breaks the tie in insertion order.
+			db.select().from(artworks).orderBy(desc(artworks.createdAt), desc(artworks.id)).limit(DASHBOARD_LIMIT),
+			db.select().from(collections).orderBy(desc(collections.createdAt), desc(collections.id)).limit(DASHBOARD_LIMIT),
+			db.select().from(products).orderBy(desc(products.createdAt), desc(products.id)).limit(DASHBOARD_LIMIT),
 			db.select(publishedTally(artworks.publishedAt)).from(artworks),
 			db.select(publishedTally(collections.publishedAt)).from(collections),
 			db
 				.select({
 					total: sql<number>`count(*)`,
-					available: sql<number>`sum(case when ${products.soldAt} is null and coalesce(${products.quantity}, 0) > 0 then 1 else 0 end)`,
-					sold: sql<number>`sum(case when ${products.soldAt} is not null then 1 else 0 end)`,
+					available: sql<number>`coalesce(sum(case when ${products.soldAt} is null and coalesce(${products.quantity}, 0) > 0 then 1 else 0 end), 0)`,
+					sold: sql<number>`coalesce(sum(case when ${products.soldAt} is not null then 1 else 0 end), 0)`,
 				})
 				.from(products),
 		]);

--- a/code/src/db/admin.ts
+++ b/code/src/db/admin.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 
 import type { ArtworkAdminInput, CollectionAdminInput } from "../lib/admin-input";
 import {
@@ -217,6 +217,179 @@ export async function getAdminArtwork(env: Env, slug: string) {
 		db.select().from(products).where(and(eq(products.artworkId, artwork.id), eq(products.type, "artwork"))),
 	]);
 	return { ...artwork, images, collectionIds: memberships.map((row) => row.collectionId), product: productRows[0] ?? null };
+}
+
+// Dashboard shapes. The dashboard is the only admin surface that reads every
+// entity at once, so it keeps its own narrow projections instead of loading the
+// full rows the editors need.
+export interface DashboardArtwork {
+	slug: string;
+	title: string;
+	year: number | null;
+	publishedAt: Date | null;
+	imageUrl: string | null;
+}
+
+export interface DashboardCollection {
+	slug: string;
+	name: string;
+	publishedAt: Date | null;
+	artworkCount: number;
+	coverUrls: string[];
+}
+
+export interface DashboardProduct {
+	slug: string;
+	name: string;
+	priceCents: number;
+	imageUrl: string | null;
+	artworkSlug: string | null;
+	soldAt: Date | null;
+	quantity: number | null;
+}
+
+export interface DashboardTally {
+	total: number;
+	published: number;
+}
+
+export interface AdminDashboard {
+	artworks: { recent: DashboardArtwork[]; tally: DashboardTally };
+	collections: { recent: DashboardCollection[]; tally: DashboardTally };
+	store: {
+		recent: DashboardProduct[];
+		tally: { total: number; available: number; sold: number };
+	};
+}
+
+const DASHBOARD_LIMIT = 3;
+
+const publishedTally = (column: typeof artworks.publishedAt | typeof collections.publishedAt) => ({
+	total: sql<number>`count(*)`,
+	published: sql<number>`sum(case when ${column} is not null then 1 else 0 end)`,
+});
+
+// One artwork can carry several images; the dashboard needs exactly one, and it
+// must agree with the cover the public catalog shows.
+function defaultImageOf(images: { url: string; isDefault: boolean }[]) {
+	return images.find((image) => image.isDefault)?.url ?? images[0]?.url ?? null;
+}
+
+export async function getAdminDashboard(env: Env, db = getDb(env)): Promise<AdminDashboard> {
+	const [artworkRows, collectionRows, productRows, artworkTally, collectionTally, storeTally] =
+		await Promise.all([
+			db.select().from(artworks).orderBy(desc(artworks.createdAt)).limit(DASHBOARD_LIMIT),
+			db.select().from(collections).orderBy(desc(collections.createdAt)).limit(DASHBOARD_LIMIT),
+			db.select().from(products).orderBy(desc(products.createdAt)).limit(DASHBOARD_LIMIT),
+			db.select(publishedTally(artworks.publishedAt)).from(artworks),
+			db.select(publishedTally(collections.publishedAt)).from(collections),
+			db
+				.select({
+					total: sql<number>`count(*)`,
+					available: sql<number>`sum(case when ${products.soldAt} is null and coalesce(${products.quantity}, 0) > 0 then 1 else 0 end)`,
+					sold: sql<number>`sum(case when ${products.soldAt} is not null then 1 else 0 end)`,
+				})
+				.from(products),
+		]);
+
+	const artworkIds = artworkRows.map((artwork) => artwork.id);
+	const collectionIds = collectionRows.map((collection) => collection.id);
+	// A product is edited through its artwork, so each card needs the artwork slug.
+	const productArtworkIds = productRows
+		.map((product) => product.artworkId)
+		.filter((id): id is number => id !== null);
+
+	const [imageRows, membershipRows, productArtworkRows] = await Promise.all([
+		artworkIds.length
+			? db.select().from(artworkImages).where(inArray(artworkImages.artworkId, artworkIds))
+			: Promise.resolve([] as (typeof artworkImages.$inferSelect)[]),
+		collectionIds.length
+			? db
+					.select({
+						collectionId: artworksToCollections.collectionId,
+						artworkId: artworksToCollections.artworkId,
+						isCover: artworksToCollections.isDefaultForCollection,
+						url: artworkImages.url,
+						isDefault: artworkImages.isDefault,
+					})
+					.from(artworksToCollections)
+					.leftJoin(artworkImages, eq(artworkImages.artworkId, artworksToCollections.artworkId))
+					.where(inArray(artworksToCollections.collectionId, collectionIds))
+			: Promise.resolve([] as { collectionId: number; artworkId: number; isCover: boolean; url: string | null; isDefault: boolean | null }[]),
+		productArtworkIds.length
+			? db
+					.select({ id: artworks.id, slug: artworks.slug })
+					.from(artworks)
+					.where(inArray(artworks.id, productArtworkIds))
+			: Promise.resolve([] as { id: number; slug: string }[]),
+	]);
+
+	const artworkSlugById = new Map(productArtworkRows.map((row) => [row.id, row.slug]));
+
+	const imagesByArtwork = new Map<number, { url: string; isDefault: boolean }[]>();
+	for (const image of imageRows) {
+		const bucket = imagesByArtwork.get(image.artworkId) ?? [];
+		bucket.push({ url: image.url, isDefault: image.isDefault });
+		imagesByArtwork.set(image.artworkId, bucket);
+	}
+
+	// The join fans out one row per (artwork, image) pair, so members are folded
+	// back per artwork before the cover artwork is promoted to the front.
+	const membersByCollection = new Map<
+		number,
+		Map<number, { isCover: boolean; images: { url: string; isDefault: boolean }[] }>
+	>();
+	for (const row of membershipRows) {
+		const members = membersByCollection.get(row.collectionId) ?? new Map();
+		const member = members.get(row.artworkId) ?? { isCover: false, images: [] };
+		member.isCover = member.isCover || row.isCover;
+		if (row.url) member.images.push({ url: row.url, isDefault: row.isDefault ?? false });
+		members.set(row.artworkId, member);
+		membersByCollection.set(row.collectionId, members);
+	}
+
+	return {
+		artworks: {
+			recent: artworkRows.map((artwork) => ({
+				slug: artwork.slug,
+				title: artwork.title,
+				year: artwork.year,
+				publishedAt: artwork.publishedAt,
+				imageUrl: defaultImageOf(imagesByArtwork.get(artwork.id) ?? []),
+			})),
+			tally: artworkTally[0] ?? { total: 0, published: 0 },
+		},
+		collections: {
+			recent: collectionRows.map((collection) => {
+				const members = Array.from(membersByCollection.get(collection.id)?.values() ?? []);
+				const coverUrls = members
+					.sort((left, right) => Number(right.isCover) - Number(left.isCover))
+					.map((member) => defaultImageOf(member.images))
+					.filter((url): url is string => url !== null)
+					.slice(0, DASHBOARD_LIMIT);
+				return {
+					slug: collection.slug,
+					name: collection.name,
+					publishedAt: collection.publishedAt,
+					artworkCount: members.length,
+					coverUrls,
+				};
+			}),
+			tally: collectionTally[0] ?? { total: 0, published: 0 },
+		},
+		store: {
+			recent: productRows.map((product) => ({
+				slug: product.slug,
+				name: product.name,
+				priceCents: product.price,
+				imageUrl: product.imageUrl,
+				artworkSlug: product.artworkId === null ? null : artworkSlugById.get(product.artworkId) ?? null,
+				soldAt: product.soldAt,
+				quantity: product.quantity,
+			})),
+			tally: storeTally[0] ?? { total: 0, available: 0, sold: 0 },
+		},
+	};
 }
 
 export async function getAdminCollection(env: Env, slug: string) {

--- a/code/src/pages/admin.astro
+++ b/code/src/pages/admin.astro
@@ -247,6 +247,15 @@ const postTypeLabels: Record<string, string> = {
 	</div>
 </BaseLayout>
 
+<style is:global>
+	/* The console commits to dark on this route only, so the footer and any
+	   overscroll stay in the same room as the page. */
+	body:has(.console) {
+		background: #050506;
+		color: #ece7dd;
+	}
+</style>
+
 <style>
 	/* The console commits to dark: the shared navbar draws its wordmark in white,
 	   and the artwork reads correctly against an unlit gallery wall. */
@@ -517,6 +526,16 @@ const postTypeLabels: Record<string, string> = {
 
 	.card:hover .stack .layer-1 { transform: translateX(0); }
 	.card:hover .stack .layer-2 { transform: translateX(0); }
+
+	/* An empty frame is common for posts, which usually carry no cover. Hatching
+	   reads as a prepared surface rather than a hole in the page. */
+	.frame:has(> .no-image) {
+		background-image: repeating-linear-gradient(
+			-45deg,
+			rgba(236, 231, 221, 0.05) 0 1px,
+			transparent 1px 9px
+		);
+	}
 
 	.no-image {
 		position: absolute;

--- a/code/src/pages/admin.astro
+++ b/code/src/pages/admin.astro
@@ -1,45 +1,612 @@
 ---
+import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { getAdminDashboard } from '../db/admin';
 import { requireAdminPage } from '../lib/admin-guard';
 import { getRuntimeEnv } from '../lib/runtime-env';
 
 export const prerender = false;
 
-const access = await requireAdminPage(Astro.request, getRuntimeEnv(), '/admin');
+const env = getRuntimeEnv();
+const access = await requireAdminPage(Astro.request, env, '/admin');
 if ('response' in access) return access.response;
 const { session } = access;
+
+const dashboard = await getAdminDashboard(env);
+
+// Posts still live in content files, so the console lists them without an
+// in-browser create action. Drafts sort first: they are the rows an editor came
+// here to finish.
+const postEntries = await getCollection('posts');
+const posts = postEntries
+	.map((post) => {
+		const stamp = post.data.publishedAt ?? post.data.scheduledAt ?? null;
+		const date = stamp ? new Date(stamp) : null;
+		return {
+			slug: post.id,
+			title: post.data.title,
+			coverImageUrl: post.data.coverImageUrl ?? null,
+			postType: post.data.postType,
+			date: date && !Number.isNaN(date.getTime()) ? date : null,
+		};
+	})
+	.sort((left, right) => (right.date?.getTime() ?? Infinity) - (left.date?.getTime() ?? Infinity))
+	.slice(0, 3);
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+const priceFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+const formatDate = (value: Date | null) => (value ? dateFormatter.format(value) : null);
+const formatPrice = (cents: number) => priceFormatter.format(cents / 100);
+
+const { artworks, collections, store } = dashboard;
+const postTypeLabels: Record<string, string> = {
+	announcement: 'Announcement',
+	educational: 'Educational',
+	behind_the_scenes: 'Behind the scenes',
+	general: 'General',
+};
 ---
-<BaseLayout title="Admin — EONMUN" description="EONMUN administration.">
-	<main class="container mx-auto px-4 py-8">
-		<div class="mb-8">
-			<h1 class="text-4xl font-bold mb-2 uppercase tracking-wider">Admin</h1>
-			<p class="text-gray-600 dark:text-gray-400">
-				Signed in as {session.user.email}.
-			</p>
-		</div>
+<BaseLayout title="Admin — EONMUN" description="EONMUN studio console.">
+	<div class="console">
+		<div class="ground" aria-hidden="true"></div>
+		<div class="wrap">
+			<header class="masthead">
+				<div>
+					<p class="eyebrow">Studio console</p>
+					<h1 class="title">Admin</h1>
+				</div>
+				<div class="identity">
+					<span class="email">{session.user.email}</span>
+					<a class="signout" href="/api/auth/signout">Sign out</a>
+				</div>
+			</header>
 
-		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-			<a href="/admin/artworks" class="block border border-gray-200 dark:border-gray-700 rounded-lg p-5 hover:border-gray-500">
-				<h2 class="text-xl font-semibold mb-2">Artwork</h2>
-				<p class="text-sm text-gray-600 dark:text-gray-400">Create, edit, and publish artwork.</p>
-			</a>
-			<a href="/posts" class="block border border-gray-200 dark:border-gray-700 rounded-lg p-5 hover:border-gray-500">
-				<h2 class="text-xl font-semibold mb-2">Posts</h2>
-				<p class="text-sm text-gray-600 dark:text-gray-400">Review published studio posts.</p>
-			</a>
-			<a href="/admin/collections" class="block border border-gray-200 dark:border-gray-700 rounded-lg p-5 hover:border-gray-500">
-				<h2 class="text-xl font-semibold mb-2">Collections</h2>
-				<p class="text-sm text-gray-600 dark:text-gray-400">Manage artwork collections.</p>
-			</a>
-		</div>
+			<div class="actions">
+				<a class="action reveal" href="/admin/artworks/new" style="animation-delay: 60ms">
+					<span class="seal" aria-hidden="true">+</span>
+					<span class="action-copy">
+						<span class="action-title">New artwork</span>
+						<span class="action-note">Images, dimensions, collections, private price.</span>
+					</span>
+					<span class="action-arrow" aria-hidden="true">&rarr;</span>
+				</a>
+				<a class="action reveal" href="/admin/collections/new" style="animation-delay: 120ms">
+					<span class="seal" aria-hidden="true">+</span>
+					<span class="action-copy">
+						<span class="action-title">New collection</span>
+						<span class="action-note">Group artwork and choose the cover piece.</span>
+					</span>
+					<span class="action-arrow" aria-hidden="true">&rarr;</span>
+				</a>
+			</div>
 
-		<div class="mt-8">
-			<a
-				href="/api/auth/signout"
-				class="inline-flex px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:border-gray-500"
-			>
-				Sign out
-			</a>
+			<section class="entity reveal" style="animation-delay: 180ms">
+				<div class="entity-head">
+					<h2><span class="index">01</span> Artwork</h2>
+					<p class="tally">
+						{artworks.tally.total} total &middot; {artworks.tally.published} published &middot;
+						{artworks.tally.total - artworks.tally.published} draft
+					</p>
+					<div class="entity-links">
+						<a class="ghost" href="/admin/artworks/new">New</a>
+						<a class="ghost" href="/admin/artworks">All artwork &rarr;</a>
+					</div>
+				</div>
+				{artworks.recent.length === 0 ? (
+					<a class="empty" href="/admin/artworks/new">No artwork yet. Add the first piece &rarr;</a>
+				) : (
+					<ul class="grid">
+						{artworks.recent.map((artwork) => (
+							<li>
+								<a class="card" href={`/admin/artworks/${artwork.slug}`}>
+									<span class="frame portrait">
+										{artwork.imageUrl ? (
+											<img src={artwork.imageUrl} alt="" loading="lazy" />
+										) : (
+											<span class="no-image">No image</span>
+										)}
+										<span class:list={['status', artwork.publishedAt ? 'is-live' : 'is-draft']}>
+											{artwork.publishedAt ? 'Published' : 'Draft'}
+										</span>
+									</span>
+									<span class="card-body">
+										<span class="card-title">{artwork.title}</span>
+										<span class="card-meta">{artwork.year ?? 'Year unset'}</span>
+									</span>
+								</a>
+							</li>
+						))}
+					</ul>
+				)}
+			</section>
+
+			<section class="entity reveal" style="animation-delay: 240ms">
+				<div class="entity-head">
+					<h2><span class="index">02</span> Collections</h2>
+					<p class="tally">
+						{collections.tally.total} total &middot; {collections.tally.published} published &middot;
+						{collections.tally.total - collections.tally.published} draft
+					</p>
+					<div class="entity-links">
+						<a class="ghost" href="/admin/collections/new">New</a>
+						<a class="ghost" href="/admin/collections">All collections &rarr;</a>
+					</div>
+				</div>
+				{collections.recent.length === 0 ? (
+					<a class="empty" href="/admin/collections/new">No collections yet. Group your first pieces &rarr;</a>
+				) : (
+					<ul class="grid">
+						{collections.recent.map((collection) => (
+							<li>
+								<a class="card" href={`/admin/collections/${collection.slug}`}>
+									<span class="frame stack">
+										{collection.coverUrls.length === 0 ? (
+											<span class="no-image">No artwork</span>
+										) : (
+											collection.coverUrls.map((url, index) => (
+												<img class={`layer layer-${index}`} src={url} alt="" loading="lazy" />
+											))
+										)}
+										<span class:list={['status', collection.publishedAt ? 'is-live' : 'is-draft']}>
+											{collection.publishedAt ? 'Published' : 'Draft'}
+										</span>
+									</span>
+									<span class="card-body">
+										<span class="card-title">{collection.name}</span>
+										<span class="card-meta">
+											{collection.artworkCount} {collection.artworkCount === 1 ? 'artwork' : 'artworks'}
+										</span>
+									</span>
+								</a>
+							</li>
+						))}
+					</ul>
+				)}
+			</section>
+
+			<section class="entity reveal" style="animation-delay: 300ms">
+				<div class="entity-head">
+					<h2><span class="index">03</span> Private sales</h2>
+					<p class="tally">
+						{store.tally.total} listed &middot; {store.tally.available} available &middot; {store.tally.sold} sold
+					</p>
+					<div class="entity-links">
+						<a class="ghost" href="/admin/artworks/new">New</a>
+						<a class="ghost" href="/admin/artworks">All artwork &rarr;</a>
+					</div>
+				</div>
+				{store.recent.length === 0 ? (
+					<a class="empty" href="/admin/artworks/new">Nothing listed. Give an artwork a price &rarr;</a>
+				) : (
+					<ul class="grid">
+						{store.recent.map((product) => (
+							<li>
+								<a
+									class="card"
+									href={product.artworkSlug ? `/admin/artworks/${product.artworkSlug}` : '/admin/artworks'}
+								>
+									<span class="frame landscape">
+										{product.imageUrl ? (
+											<img src={product.imageUrl} alt="" loading="lazy" />
+										) : (
+											<span class="no-image">No image</span>
+										)}
+										<span
+											class:list={[
+												'status',
+												product.soldAt ? 'is-sold' : (product.quantity ?? 0) > 0 ? 'is-live' : 'is-draft',
+											]}
+										>
+											{product.soldAt ? 'Sold' : (product.quantity ?? 0) > 0 ? 'Available' : 'Reserved'}
+										</span>
+									</span>
+									<span class="card-body">
+										<span class="card-title">{product.name}</span>
+										<span class="card-meta price">{formatPrice(product.priceCents)}</span>
+									</span>
+								</a>
+							</li>
+						))}
+					</ul>
+				)}
+			</section>
+
+			<section class="entity reveal" style="animation-delay: 360ms">
+				<div class="entity-head">
+					<h2><span class="index">04</span> Posts</h2>
+					<p class="tally">{postEntries.length} written &middot; edited in the repository</p>
+					<div class="entity-links">
+						<a class="ghost" href="/posts">All posts &rarr;</a>
+					</div>
+				</div>
+				{posts.length === 0 ? (
+					<p class="empty is-static">No posts yet.</p>
+				) : (
+					<ul class="grid">
+						{posts.map((post) => (
+							<li>
+								<a class="card" href={`/posts/${post.slug}`}>
+									<span class="frame landscape">
+										{post.coverImageUrl ? (
+											<img src={post.coverImageUrl} alt="" loading="lazy" />
+										) : (
+											<span class="no-image">{postTypeLabels[post.postType] ?? 'Post'}</span>
+										)}
+									</span>
+									<span class="card-body">
+										<span class="card-title">{post.title}</span>
+										<span class="card-meta">{formatDate(post.date) ?? 'Unscheduled'}</span>
+									</span>
+								</a>
+							</li>
+						))}
+					</ul>
+				)}
+			</section>
 		</div>
-	</main>
+	</div>
 </BaseLayout>
+
+<style>
+	/* The console commits to dark: the shared navbar draws its wordmark in white,
+	   and the artwork reads correctly against an unlit gallery wall. */
+	.console {
+		--ink: #08080a;
+		--paper: #ece7dd;
+		--muted: rgba(236, 231, 221, 0.55);
+		--hair: rgba(236, 231, 221, 0.16);
+		--seal: #c1452c;
+		position: relative;
+		min-height: 100vh;
+		margin-top: -4.5rem;
+		padding: 4.5rem 0 6rem;
+		color: var(--paper);
+	}
+
+	.ground {
+		position: fixed;
+		inset: 0;
+		z-index: -1;
+		background:
+			radial-gradient(120% 80% at 50% -10%, #17161a 0%, var(--ink) 55%, #050506 100%);
+	}
+
+	.ground::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		opacity: 0.28;
+		mix-blend-mode: overlay;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+	}
+
+	.wrap {
+		width: min(88rem, 100%);
+		margin: 0 auto;
+		padding: 0 clamp(1rem, 4vw, 3.5rem);
+	}
+
+	.masthead {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 1.5rem;
+		padding: clamp(2.5rem, 7vw, 5rem) 0 2rem;
+		border-bottom: 1px solid var(--hair);
+	}
+
+	.eyebrow {
+		margin: 0 0 0.75rem;
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.42em;
+		color: var(--seal);
+	}
+
+	.title {
+		margin: 0;
+		font-size: clamp(3rem, 11vw, 7rem);
+		line-height: 0.85;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
+
+	.identity {
+		display: flex;
+		align-items: center;
+		gap: 1.25rem;
+		font-size: 0.78rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+	}
+
+	.email {
+		color: var(--muted);
+	}
+
+	.signout {
+		padding: 0.5rem 1.1rem;
+		border: 1px solid var(--hair);
+		color: var(--paper);
+		transition: border-color 200ms, color 200ms;
+	}
+
+	.signout:hover {
+		border-color: var(--seal);
+		color: var(--seal);
+	}
+
+	.actions {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
+		gap: 1px;
+		margin: 2.5rem 0 4rem;
+		background: var(--hair);
+		border: 1px solid var(--hair);
+	}
+
+	.action {
+		display: flex;
+		align-items: center;
+		gap: 1.25rem;
+		padding: clamp(1.5rem, 3vw, 2.25rem);
+		background: rgba(8, 8, 10, 0.75);
+		transition: background 250ms;
+	}
+
+	.action:hover {
+		background: rgba(193, 69, 44, 0.09);
+	}
+
+	.seal {
+		flex: none;
+		display: grid;
+		place-items: center;
+		width: 3rem;
+		height: 3rem;
+		font-size: 1.5rem;
+		line-height: 1;
+		color: var(--paper);
+		background: var(--seal);
+		transition: transform 250ms cubic-bezier(0.2, 0.7, 0.2, 1);
+	}
+
+	.action:hover .seal {
+		transform: rotate(-6deg) scale(1.06);
+	}
+
+	.action-copy {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.action-title {
+		font-size: 1.4rem;
+		text-transform: uppercase;
+		letter-spacing: 0.16em;
+	}
+
+	.action-note {
+		font-size: 0.85rem;
+		color: var(--muted);
+	}
+
+	.action-arrow {
+		margin-left: auto;
+		font-size: 1.4rem;
+		color: var(--muted);
+		transition: transform 250ms, color 250ms;
+	}
+
+	.action:hover .action-arrow {
+		transform: translateX(0.35rem);
+		color: var(--seal);
+	}
+
+	.entity {
+		margin-bottom: 4rem;
+	}
+
+	.entity-head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0.75rem 1.5rem;
+		padding-bottom: 1rem;
+		border-bottom: 1px solid var(--hair);
+	}
+
+	.entity-head h2 {
+		margin: 0;
+		font-size: 1.5rem;
+		text-transform: uppercase;
+		letter-spacing: 0.2em;
+	}
+
+	.index {
+		margin-right: 0.75rem;
+		font-size: 0.75rem;
+		letter-spacing: 0.2em;
+		color: var(--seal);
+		vertical-align: 0.35em;
+	}
+
+	.tally {
+		margin: 0;
+		font-size: 0.78rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--muted);
+	}
+
+	.entity-links {
+		display: flex;
+		gap: 1.25rem;
+		margin-left: auto;
+	}
+
+	.ghost {
+		font-size: 0.78rem;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		color: var(--muted);
+		transition: color 200ms;
+	}
+
+	.ghost:hover {
+		color: var(--seal);
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+		gap: clamp(1rem, 2.5vw, 2rem);
+		margin: 1.75rem 0 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.card {
+		display: block;
+	}
+
+	.frame {
+		position: relative;
+		display: block;
+		overflow: hidden;
+		background: #101013;
+		border: 1px solid var(--hair);
+	}
+
+	.portrait { aspect-ratio: 4 / 5; }
+	.landscape { aspect-ratio: 3 / 2; }
+	.stack { aspect-ratio: 3 / 2; }
+
+	.frame img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		filter: saturate(0.75) brightness(0.86);
+		transition: transform 600ms cubic-bezier(0.2, 0.7, 0.2, 1), filter 400ms;
+	}
+
+	.card:hover .frame img {
+		transform: scale(1.04);
+		filter: saturate(1) brightness(1);
+	}
+
+	.card:hover .frame {
+		border-color: rgba(236, 231, 221, 0.4);
+	}
+
+	/* Collections hold artwork rather than a single image, so their cover is a
+	   stack of member pieces fanned out like prints on a table. */
+	.stack .layer {
+		position: absolute;
+		inset: 0 0 0 auto;
+		width: 62%;
+		border-left: 1px solid rgba(8, 8, 10, 0.85);
+		transition: transform 600ms cubic-bezier(0.2, 0.7, 0.2, 1), filter 400ms;
+	}
+
+	.stack .layer-0 { left: 0; right: auto; width: 100%; z-index: 1; }
+	.stack .layer-1 { right: 0; width: 46%; z-index: 2; transform: translateX(18%); }
+	.stack .layer-2 { right: 0; width: 30%; z-index: 3; transform: translateX(36%); }
+
+	.card:hover .stack .layer-1 { transform: translateX(0); }
+	.card:hover .stack .layer-2 { transform: translateX(0); }
+
+	.no-image {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		font-size: 0.75rem;
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		color: rgba(236, 231, 221, 0.32);
+	}
+
+	.status {
+		position: absolute;
+		top: 0.75rem;
+		left: 0.75rem;
+		z-index: 4;
+		padding: 0.25rem 0.6rem;
+		font-size: 0.62rem;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		backdrop-filter: blur(6px);
+		background: rgba(8, 8, 10, 0.6);
+		border: 1px solid var(--hair);
+	}
+
+	.status.is-live { color: var(--paper); border-color: rgba(236, 231, 221, 0.45); }
+	.status.is-draft { color: var(--seal); border-color: rgba(193, 69, 44, 0.6); }
+	.status.is-sold { color: rgba(236, 231, 221, 0.5); }
+
+	.card-body {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding-top: 0.85rem;
+	}
+
+	.card-title {
+		font-size: 1.05rem;
+		letter-spacing: 0.04em;
+	}
+
+	.card-meta {
+		font-size: 0.75rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--muted);
+		white-space: nowrap;
+	}
+
+	.price { color: var(--seal); }
+
+	.empty {
+		display: block;
+		margin-top: 1.75rem;
+		padding: 2.5rem;
+		border: 1px dashed var(--hair);
+		font-size: 0.9rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--muted);
+		text-align: center;
+		transition: border-color 200ms, color 200ms;
+	}
+
+	.empty:hover {
+		border-color: var(--seal);
+		color: var(--paper);
+	}
+
+	.empty.is-static:hover {
+		border-color: var(--hair);
+		color: var(--muted);
+	}
+
+	.reveal {
+		animation: rise 700ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+	}
+
+	@keyframes rise {
+		from { opacity: 0; transform: translateY(1.25rem); }
+		to { opacity: 1; transform: none; }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.reveal { animation: none; }
+		.frame img,
+		.stack .layer,
+		.seal,
+		.action-arrow { transition: none; }
+	}
+</style>

--- a/code/src/pages/admin.astro
+++ b/code/src/pages/admin.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { getAdminDashboard } from '../db/admin';
 import { requireAdminPage } from '../lib/admin-guard';
+import { getPostPublishedDate, isPublishedPost } from '../lib/post-content';
 import { getRuntimeEnv } from '../lib/runtime-env';
 
 export const prerender = false;
@@ -15,26 +16,28 @@ const { session } = access;
 const dashboard = await getAdminDashboard(env);
 
 // Posts still live in content files, so the console lists them without an
-// in-browser create action. Drafts sort first: they are the rows an editor came
-// here to finish.
+// in-browser create action. Published state comes from the same helpers the
+// public route uses: an unpublished post has no page to open, so its card is
+// not a link. Those rows sort first — they are the ones an editor came to
+// finish.
 const postEntries = await getCollection('posts');
 const posts = postEntries
-	.map((post) => {
-		const stamp = post.data.publishedAt ?? post.data.scheduledAt ?? null;
-		const date = stamp ? new Date(stamp) : null;
-		return {
-			slug: post.id,
-			title: post.data.title,
-			coverImageUrl: post.data.coverImageUrl ?? null,
-			postType: post.data.postType,
-			date: date && !Number.isNaN(date.getTime()) ? date : null,
-		};
+	.map((post) => ({
+		slug: post.id,
+		title: post.data.title,
+		coverImageUrl: post.data.coverImageUrl ?? null,
+		postType: post.data.postType,
+		date: getPostPublishedDate(post),
+		published: isPublishedPost(post),
+	}))
+	.sort((left, right) => {
+		if (left.published !== right.published) return left.published ? 1 : -1;
+		return (right.date?.getTime() ?? 0) - (left.date?.getTime() ?? 0);
 	})
-	.sort((left, right) => (right.date?.getTime() ?? Infinity) - (left.date?.getTime() ?? Infinity))
 	.slice(0, 3);
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-const priceFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+const priceFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
 const formatDate = (value: Date | null) => (value ? dateFormatter.format(value) : null);
 const formatPrice = (cents: number) => priceFormatter.format(cents / 100);
 
@@ -197,7 +200,7 @@ const postTypeLabels: Record<string, string> = {
 												product.soldAt ? 'is-sold' : (product.quantity ?? 0) > 0 ? 'is-live' : 'is-draft',
 											]}
 										>
-											{product.soldAt ? 'Sold' : (product.quantity ?? 0) > 0 ? 'Available' : 'Reserved'}
+											{product.soldAt ? 'Sold' : (product.quantity ?? 0) > 0 ? 'Available' : 'Not for sale'}
 										</span>
 									</span>
 									<span class="card-body">
@@ -223,23 +226,29 @@ const postTypeLabels: Record<string, string> = {
 					<p class="empty is-static">No posts yet.</p>
 				) : (
 					<ul class="grid">
-						{posts.map((post) => (
-							<li>
-								<a class="card" href={`/posts/${post.slug}`}>
-									<span class="frame landscape">
-										{post.coverImageUrl ? (
-											<img src={post.coverImageUrl} alt="" loading="lazy" />
-										) : (
-											<span class="no-image">{postTypeLabels[post.postType] ?? 'Post'}</span>
-										)}
-									</span>
-									<span class="card-body">
-										<span class="card-title">{post.title}</span>
-										<span class="card-meta">{formatDate(post.date) ?? 'Unscheduled'}</span>
-									</span>
-								</a>
-							</li>
-						))}
+						{posts.map((post) => {
+							const Card = post.published ? 'a' : 'div';
+							return (
+								<li>
+									<Card class="card" href={post.published ? `/posts/${post.slug}` : undefined}>
+										<span class="frame landscape">
+											{post.coverImageUrl ? (
+												<img src={post.coverImageUrl} alt="" loading="lazy" />
+											) : (
+												<span class="no-image">{postTypeLabels[post.postType] ?? 'Post'}</span>
+											)}
+											{!post.published && (
+												<span class="status is-draft">{post.date ? 'Scheduled' : 'Draft'}</span>
+											)}
+										</span>
+										<span class="card-body">
+											<span class="card-title">{post.title}</span>
+											<span class="card-meta">{formatDate(post.date) ?? 'Unscheduled'}</span>
+										</span>
+									</Card>
+								</li>
+							);
+						})}
 					</ul>
 				)}
 			</section>


### PR DESCRIPTION
## What

`/admin` listed three text tiles and no work state. This rebuilds it as a dark studio console:

- **Create actions first.** Large "New artwork" and "New collection" actions at the top, each with a seal glyph and a note on what the form covers.
- **Latest three per entity.** Artwork, Collections, Private sales, and Posts each show their three most recent items as image cards with a status pill and a tally line, plus `New` / `All …` links in every section header. Empty states link straight to the create route.
- **Covers for collections.** Collections carry no image of their own, so their cover is derived from member artwork — the collection's cover piece promoted first — and fanned out as a stack that squares up on hover.
- **Committed to dark.** The shared navbar draws its wordmark in white, so the previous light admin rendered EONMUN white-on-white.

`getAdminDashboard` reads the recent rows, their covers, and the tallies in one pass.

## Review fixes included

An adversarial review of the first two commits found five defects, all fixed in d6e246c:

| Defect | Fix |
| --- | --- |
| Empty tallies rendered blank — `SUM` over zero rows is `NULL` in SQLite, and an ungrouped aggregate always returns a row, so the array fallbacks never fired | `coalesce(sum(…), 0)` on each conditional count |
| "Latest three" was arbitrary among rows sharing a `created_at` second (the column stores whole seconds) | `desc(id)` tiebreak on all three recency queries |
| A 45678-cent listing displayed as `$457` | Dropped `maximumFractionDigits: 0` |
| Post cards linked every row to `/posts/<slug>`, which 404s for unpublished posts — the rows the section sorts first | Published state now comes from `isPublishedPost` / `getPostPublishedDate`; unpublished posts render as non-link cards marked Draft or Scheduled |
| "Reserved" implied a buyer held the piece when the artist had only left "Available for purchase" unchecked | Reads "Not for sale", matching `lib/inventory.ts` |

## Verification

- `bun run build` passes; `bun test` is 51 pass / 0 fail.
- Rendered against a seeded local database (sqld over the devenv fixture db) at 1440px and 390px.
- Tally and ordering fixes checked by calling `getAdminDashboard` against a throwaway libsql database: empty tables return zeroed tallies, and four rows written in the same second return deterministically.
- Draft-post rendering and price formatting checked in the real page output with a temporary draft fixture and a fractional price, both reverted.

## Known follow-ups (not in this PR)

- `getAdminDashboard` has no test, though `code/test/admin-mutations.test.ts` already provides the db-injection harness.
- Artwork image folding re-implements in JS what `queries.ts` does with `eq(artworkImages.isDefault, true)` in the join; `defaultImageOf` duplicates `defaultImageUrl` in the same file.
- Post date parsing and type labels partly duplicate `lib/post-content.ts`.
- `.no-image` placeholder text sits near 2.5:1 contrast, below WCAG AA.
- `DASHBOARD_LIMIT` governs both the recency slice and the cover stack, which has only three styled `.layer-N` rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWkvt4PUhp5xVW7AE7U18B