### PR TITLE
fix(auth): stop returning immutable redirects through Astro

### DIFF
--- a/code/src/lib/admin-guard.ts
+++ b/code/src/lib/admin-guard.ts
@@ -1,4 +1,5 @@
 import { getSession, getSignInUrl, type AdminSession, type AuthEnv } from "./auth";
+import { redirectResponse } from "./redirect";
 
 export function isSameOriginRequest(request: Request) {
 	const origin = request.headers.get("origin");
@@ -28,7 +29,7 @@ export async function requireAdminPage(request: Request, env: AuthEnv, callbackP
 	const session = await getSession(request, env);
 	return session
 		? { session }
-		: { response: Response.redirect(getSignInUrl(request, callbackPath), 302) };
+		: { response: redirectResponse(getSignInUrl(request, callbackPath), 302) };
 }
 
 export function mutationError(error: unknown) {

--- a/code/src/lib/checkout.ts
+++ b/code/src/lib/checkout.ts
@@ -1,4 +1,5 @@
 import { SLUG_PATTERN } from "./slug";
+import { redirectResponse } from "./redirect";
 
 export interface CheckoutItem {
 	artworkSlug: string;
@@ -78,7 +79,7 @@ export async function handleCheckoutRequest(
 		const item = await lookup(artworkSlug);
 		if (!item) return Response.json({ error: "Artwork is not available" }, { status: 409 });
 		const url = await createSession(secretKey, item, new URL(request.url).origin);
-		return Response.redirect(url, 303);
+		return redirectResponse(url, 303);
 	} catch (error) {
 		if (error instanceof CheckoutValidationError) {
 			return Response.json({ error: error.message }, { status: 400 });

--- a/code/src/lib/redirect.ts
+++ b/code/src/lib/redirect.ts
@@ -1,0 +1,7 @@
+// Response.redirect() returns a response whose headers are immutable, and Astro
+// sets headers on whatever a route hands back. On Cloudflare that combination
+// throws "TypeError: Can't modify immutable headers" and the redirect reaches
+// the browser as a 500. Build redirects by hand so the headers stay mutable.
+export function redirectResponse(url: string | URL, status: 301 | 302 | 303 | 307 | 308) {
+	return new Response(null, { status, headers: { location: url.toString() } });
+}

--- a/code/test/admin-guard.test.ts
+++ b/code/test/admin-guard.test.ts
@@ -30,6 +30,14 @@ describe("admin request guards", () => {
 		}
 	});
 
+	test("sends an unauthenticated dashboard request to sign-in", async () => {
+		const result = await requireAdminPage(new Request("https://eonmun.test/admin"), env, "/admin");
+		expect("response" in result).toBe(true);
+		const response = ("response" in result ? result.response : null)!;
+		expect(response.status).toBe(302);
+		expect(response.headers.get("location")).toContain("/api/auth/signin");
+	});
+
 	test("keeps invalid slug syntax as a validation error", async () => {
 		const response = mutationError(new Error("Slug must use lowercase letters, numbers, and hyphens"));
 		expect(response.status).toBe(400);

--- a/code/test/checkout.test.ts
+++ b/code/test/checkout.test.ts
@@ -52,6 +52,7 @@ describe("checkout", () => {
 		);
 		expect(receivedPrice).toBe(125000);
 		expect(response.status).toBe(303);
+		expect(response.headers.get("location")).toBe("https://checkout.stripe.com/c/pay/test");
 	});
 
 	test("refuses checkout for an unavailable artwork", async () => {

--- a/code/test/redirect.test.ts
+++ b/code/test/redirect.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { redirectResponse } from "../src/lib/redirect";
+
+const SOURCE_ROOT = path.join(import.meta.dir, "..", "src");
+
+async function sourceFiles(dir: string): Promise<string[]> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const files = await Promise.all(entries.map(async (entry) => {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) return sourceFiles(full);
+		return /\.(ts|astro|mjs)$/.test(entry.name) ? [full] : [];
+	}));
+	return files.flat();
+}
+
+describe("redirects", () => {
+	test("sets location and keeps headers mutable", () => {
+		const response = redirectResponse(new URL("https://eonmun.test/api/auth/signin"), 302);
+		expect(response.status).toBe(302);
+		expect(response.headers.get("location")).toBe("https://eonmun.test/api/auth/signin");
+		response.headers.set("x-astro-middleware", "1");
+		expect(response.headers.get("x-astro-middleware")).toBe("1");
+	});
+
+	// Response.redirect() returns a response whose headers are immutable. Astro
+	// sets headers on whatever a route returns, so on workerd that pairing throws
+	// "Can't modify immutable headers" and the redirect reaches the browser as a
+	// 500 — which took every /admin route and the Stripe hand-off down in
+	// production. Bun does not enforce header immutability, so no assertion on a
+	// response object can reproduce it; this test bans the constructor instead.
+	// Astro.redirect() inside a .astro page is fine and stays allowed.
+	test("no source file returns Response.redirect", async () => {
+		const offenders: string[] = [];
+		for (const file of await sourceFiles(SOURCE_ROOT)) {
+			const contents = await readFile(file, "utf8");
+			// Comment lines may name the banned call while explaining the ban.
+			const code = contents
+				.split("\n")
+				.filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+				.join("\n");
+			if (code.includes("Response.redirect(")) {
+				offenders.push(path.relative(SOURCE_ROOT, file));
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Production is down on /admin

Every admin route returns 500 on https://eonmun.com — `/admin`, `/admin/artworks`, `/admin/collections`, `/admin/artworks/new`. Public pages are fine.

`wrangler tail eonmun-astro` gives the cause:

```
TypeError: Can't modify immutable headers
    at PagesHandler.handle (chunks/worker-entry_DyqRZBw7.mjs:12105:26)
    at async callMiddleware
    at async AstroMiddleware.handle
    at async AstroHandler.render
```

`Response.redirect()` returns a response whose headers are **immutable**, and Astro sets headers on whatever a route hands back. On workerd that pairing throws, so the sign-in redirect never reaches the browser — it becomes a 500.

This predates #86: `admin-guard.ts` has used `Response.redirect` since d445583 (the Turso catalog commit), and the routes that fail include three that #86 never touched. The behavior arrived in production when d445583 deployed at 12:01 UTC today.

## Also on the payment path

`handleCheckoutRequest` ends with the same call (`lib/checkout.ts:81`, `return Response.redirect(url, 303)`), returned straight out of `POST /api/checkout`. A buyer clicking purchase gets a 500 instead of Stripe Checkout. Fixed here too.

## The fix

`redirectResponse(url, status)` builds the response by hand so the headers stay mutable, used at both call sites. `Astro.redirect()` inside a `.astro` page is unaffected and stays in use elsewhere.

## About the test

Bun **does not** enforce header immutability — verified directly:

```
BUN: Response.redirect headers MUTABLE (set ok)
```

So an assertion like `expect(() => response.headers.set(...)).not.toThrow()` passes with or without the fix and would never have caught this. Instead `test/redirect.test.ts` bans `Response.redirect(` across `src/` (ignoring comment lines) and unit-tests `redirectResponse` itself.

Negative control: reintroducing the call at either site fails the guard test, naming the file.

```
+   "lib/admin-guard.ts",
(fail) redirects > no source file returns Response.redirect
```

## Verification

- `bun test`: 54 pass, 0 fail. `bun run build` passes.
- Unit tests cannot prove the workerd behavior — **the preview deploy on this PR is the real check**: `/admin` should answer 302 to `/api/auth/signin` rather than 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWkvt4PUhp5xVW7AE7U18B