### PR TITLE
feat(admin): give the artwork and collection pages the console treatment

### DIFF
--- a/code/src/components/admin/ActionBar.astro
+++ b/code/src/components/admin/ActionBar.astro
@@ -1,0 +1,17 @@
+---
+// The band of primary create actions under the masthead. Hairline dividers come
+// from the 1px gap over the border colour, so the gap, background and border
+// have to stay together — which is why this is a component and not three copies.
+---
+<div class="actions"><slot /></div>
+
+<style>
+	.actions {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
+		gap: 1px;
+		margin: 2.5rem 0 4rem;
+		background: var(--hair);
+		border: 1px solid var(--hair);
+	}
+</style>

--- a/code/src/components/admin/CardCaption.astro
+++ b/code/src/components/admin/CardCaption.astro
@@ -1,0 +1,39 @@
+---
+// The line under a card: what the item is, and one fact about it.
+interface Props {
+	title: string;
+	meta?: string | null;
+	metaTone?: 'default' | 'seal';
+}
+
+const { title, meta, metaTone = 'default' } = Astro.props;
+---
+<span class="card-body">
+	<span class="card-title">{title}</span>
+	{meta && <span class:list={['card-meta', { seal: metaTone === 'seal' }]}>{meta}</span>}
+</span>
+
+<style>
+	.card-body {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding-top: 0.85rem;
+	}
+
+	.card-title {
+		font-size: 1.05rem;
+		letter-spacing: 0.04em;
+	}
+
+	.card-meta {
+		font-size: 0.75rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--muted);
+		white-space: nowrap;
+	}
+
+	.card-meta.seal { color: var(--seal); }
+</style>

--- a/code/src/components/admin/CardGrid.astro
+++ b/code/src/components/admin/CardGrid.astro
@@ -1,7 +1,8 @@
 ---
 // The console's one grid rhythm, shared by every section that lists items.
+// role="list" keeps the semantics VoiceOver drops from list-style: none.
 ---
-<ul class="grid"><slot /></ul>
+<ul class="grid" role="list"><slot /></ul>
 
 <style>
 	.grid {

--- a/code/src/components/admin/CardGrid.astro
+++ b/code/src/components/admin/CardGrid.astro
@@ -1,0 +1,15 @@
+---
+// The console's one grid rhythm, shared by every section that lists items.
+---
+<ul class="grid"><slot /></ul>
+
+<style>
+	.grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+		gap: clamp(1rem, 2.5vw, 2rem);
+		margin: 1.75rem 0 0;
+		padding: 0;
+		list-style: none;
+	}
+</style>

--- a/code/src/components/admin/ConsoleSection.astro
+++ b/code/src/components/admin/ConsoleSection.astro
@@ -6,12 +6,11 @@ interface Props {
 	title: string;
 	tally?: string;
 	links?: { href: string; label: string }[];
-	delay?: number;
 }
 
-const { index, title, tally, links = [], delay } = Astro.props;
+const { index, title, tally, links = [] } = Astro.props;
 ---
-<section class="entity reveal" style={delay === undefined ? undefined : `animation-delay: ${delay}ms`}>
+<section class="entity">
 	<div class="entity-head">
 		<h2>{index && <span class="index">{index}</span>}{title}</h2>
 		{tally && <p class="tally">{tally}</p>}
@@ -79,16 +78,4 @@ const { index, title, tally, links = [], delay } = Astro.props;
 		color: var(--seal);
 	}
 
-	.reveal {
-		animation: rise 700ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
-	}
-
-	@keyframes rise {
-		from { opacity: 0; transform: translateY(1.25rem); }
-		to { opacity: 1; transform: none; }
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.reveal { animation: none; }
-	}
 </style>

--- a/code/src/components/admin/ConsoleSection.astro
+++ b/code/src/components/admin/ConsoleSection.astro
@@ -1,0 +1,94 @@
+---
+// A titled band of the console: numbered heading, a tally line, and the links
+// that act on that entity. The section owns the grid its slot content sits in.
+interface Props {
+	index?: string;
+	title: string;
+	tally?: string;
+	links?: { href: string; label: string }[];
+	delay?: number;
+}
+
+const { index, title, tally, links = [], delay } = Astro.props;
+---
+<section class="entity reveal" style={delay === undefined ? undefined : `animation-delay: ${delay}ms`}>
+	<div class="entity-head">
+		<h2>{index && <span class="index">{index}</span>}{title}</h2>
+		{tally && <p class="tally">{tally}</p>}
+		{links.length > 0 && (
+			<div class="entity-links">
+				{links.map((link) => <a class="ghost" href={link.href}>{link.label}</a>)}
+			</div>
+		)}
+	</div>
+	<slot />
+</section>
+
+<style>
+	.entity {
+		margin-bottom: 4rem;
+	}
+
+	.entity-head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0.75rem 1.5rem;
+		padding-bottom: 1rem;
+		border-bottom: 1px solid var(--hair);
+	}
+
+	.entity-head h2 {
+		margin: 0;
+		font-size: 1.5rem;
+		text-transform: uppercase;
+		letter-spacing: 0.2em;
+	}
+
+	.index {
+		margin-right: 0.75rem;
+		font-size: 0.75rem;
+		letter-spacing: 0.2em;
+		color: var(--seal);
+		vertical-align: 0.35em;
+	}
+
+	.tally {
+		margin: 0;
+		font-size: 0.78rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--muted);
+	}
+
+	.entity-links {
+		display: flex;
+		gap: 1.25rem;
+		margin-left: auto;
+	}
+
+	.ghost {
+		font-size: 0.78rem;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		color: var(--muted);
+		transition: color 200ms;
+	}
+
+	.ghost:hover {
+		color: var(--seal);
+	}
+
+	.reveal {
+		animation: rise 700ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+	}
+
+	@keyframes rise {
+		from { opacity: 0; transform: translateY(1.25rem); }
+		to { opacity: 1; transform: none; }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.reveal { animation: none; }
+	}
+</style>

--- a/code/src/components/admin/ConsoleShell.astro
+++ b/code/src/components/admin/ConsoleShell.astro
@@ -64,6 +64,70 @@ const {
 		--hair: rgba(236, 231, 221, 0.16);
 		--seal: #c1452c;
 	}
+
+	/* The console paints its own near-black ground, so it owes the keyboard a
+	   focus ring it has actually checked against that ground. */
+	.console :focus-visible {
+		outline: 2px solid var(--paper);
+		outline-offset: 2px;
+	}
+
+	/* One motion primitive, owned here: the shell staggers whatever a page puts
+	   in it, so no page hand-numbers animation delays. */
+	.console .wrap > * {
+		animation: console-rise 700ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+	}
+
+	.console .wrap > :nth-child(2) { animation-delay: 60ms; }
+	.console .wrap > :nth-child(3) { animation-delay: 120ms; }
+	.console .wrap > :nth-child(4) { animation-delay: 180ms; }
+	.console .wrap > :nth-child(5) { animation-delay: 240ms; }
+	.console .wrap > :nth-child(6) { animation-delay: 300ms; }
+	.console .wrap > :nth-child(n + 7) { animation-delay: 360ms; }
+
+	@keyframes console-rise {
+		from { opacity: 0; transform: translateY(1.25rem); }
+		to { opacity: 1; transform: none; }
+	}
+
+	/* The framed surface a card sits in, shared by every card type so the
+	   chrome cannot drift between them. */
+	.console .frame {
+		position: relative;
+		display: block;
+		overflow: hidden;
+		background: #101013;
+		border: 1px solid var(--hair);
+	}
+
+	/* An empty frame is common for posts, which usually carry no cover.
+	   Hatching reads as a prepared surface rather than a hole in the page. */
+	.console .frame.is-empty {
+		background-image: repeating-linear-gradient(
+			-45deg,
+			rgba(236, 231, 221, 0.05) 0 1px,
+			transparent 1px 9px
+		);
+	}
+
+	.console a.card:hover .frame {
+		border-color: rgba(236, 231, 221, 0.4);
+	}
+
+	.console .no-image {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		font-size: 0.75rem;
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		color: var(--muted);
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.console .wrap > * { animation: none; }
+	}
 </style>
 
 <style>

--- a/code/src/components/admin/ConsoleShell.astro
+++ b/code/src/components/admin/ConsoleShell.astro
@@ -1,0 +1,161 @@
+---
+// The admin console's frame: the dark ground, the palette every console
+// component reads through inherited custom properties, and the masthead.
+// Pages supply their own sections through the default slot.
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+interface Props {
+	title: string;
+	eyebrow?: string;
+	heading: string;
+	email?: string;
+	description?: string;
+	backHref?: string;
+	backLabel?: string;
+}
+
+const {
+	title,
+	eyebrow = 'Studio console',
+	heading,
+	email,
+	description = 'EONMUN studio console.',
+	backHref,
+	backLabel,
+} = Astro.props;
+---
+<BaseLayout title={title} description={description}>
+	<div class="console">
+		<div class="ground" aria-hidden="true"></div>
+		<div class="wrap">
+			<header class="masthead">
+				<div>
+					{backHref ? (
+						<a class="back" href={backHref}>&larr; {backLabel ?? 'Back'}</a>
+					) : (
+						<p class="eyebrow">{eyebrow}</p>
+					)}
+					<h1 class="title">{heading}</h1>
+				</div>
+				<div class="identity">
+					{email && <span class="email">{email}</span>}
+					<a class="signout" href="/api/auth/signout">Sign out</a>
+				</div>
+			</header>
+			<slot />
+		</div>
+	</div>
+</BaseLayout>
+
+<style is:global>
+	/* The console commits to dark on its own routes, so the footer and any
+	   overscroll stay in the same room as the page. */
+	body:has(.console) {
+		background: #050506;
+		color: #ece7dd;
+	}
+
+	/* Tokens live on .console so every console component's scoped styles can
+	   read them through inheritance. */
+	.console {
+		--ink: #08080a;
+		--paper: #ece7dd;
+		--muted: rgba(236, 231, 221, 0.55);
+		--hair: rgba(236, 231, 221, 0.16);
+		--seal: #c1452c;
+	}
+</style>
+
+<style>
+	.console {
+		position: relative;
+		min-height: 100vh;
+		margin-top: -4.5rem;
+		padding: 4.5rem 0 6rem;
+		color: var(--paper);
+	}
+
+	.ground {
+		position: fixed;
+		inset: 0;
+		z-index: -1;
+		background: radial-gradient(120% 80% at 50% -10%, #17161a 0%, var(--ink) 55%, #050506 100%);
+	}
+
+	.ground::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		opacity: 0.28;
+		mix-blend-mode: overlay;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+	}
+
+	.wrap {
+		width: min(88rem, 100%);
+		margin: 0 auto;
+		padding: 0 clamp(1rem, 4vw, 3.5rem);
+	}
+
+	.masthead {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 1.5rem;
+		padding: clamp(2.5rem, 7vw, 5rem) 0 2rem;
+		border-bottom: 1px solid var(--hair);
+	}
+
+	.eyebrow,
+	.back {
+		display: inline-block;
+		margin: 0 0 0.75rem;
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.42em;
+		color: var(--seal);
+	}
+
+	.back {
+		letter-spacing: 0.24em;
+		transition: color 200ms;
+	}
+
+	.back:hover {
+		color: var(--paper);
+	}
+
+	.title {
+		margin: 0;
+		font-size: clamp(2.5rem, 9vw, 6rem);
+		line-height: 0.85;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
+
+	.identity {
+		display: flex;
+		align-items: center;
+		gap: 1.25rem;
+		font-size: 0.78rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+	}
+
+	.email {
+		color: var(--muted);
+	}
+
+	.signout {
+		padding: 0.5rem 1.1rem;
+		border: 1px solid var(--hair);
+		color: var(--paper);
+		transition: border-color 200ms, color 200ms;
+	}
+
+	.signout:hover {
+		border-color: var(--seal);
+		color: var(--seal);
+	}
+</style>

--- a/code/src/components/admin/CoverStack.astro
+++ b/code/src/components/admin/CoverStack.astro
@@ -1,0 +1,119 @@
+---
+// A collection holds artwork rather than an image of its own, so its cover is
+// a fan of member pieces that squares up on hover. Only three layers are
+// styled; COLLECTION_COVER_LAYERS in db/admin.ts caps the input to match.
+interface Props {
+	href?: string | null;
+	name: string;
+	artworkCount: number;
+	coverUrls: string[];
+	status?: { label: string; tone: 'live' | 'draft' } | null;
+}
+
+const { href, name, artworkCount, coverUrls, status } = Astro.props;
+const Card = href ? 'a' : 'div';
+---
+<Card class="card" href={href ?? undefined}>
+	<span class:list={['frame', { 'is-empty': coverUrls.length === 0 }]}>
+		{coverUrls.length === 0 ? (
+			<span class="no-image">No artwork</span>
+		) : (
+			coverUrls.map((url, index) => <img class={`layer layer-${index}`} src={url} alt="" loading="lazy" />)
+		)}
+		{status && <span class:list={['status', `is-${status.tone}`]}>{status.label}</span>}
+	</span>
+	<span class="card-body">
+		<span class="card-title">{name}</span>
+		<span class="card-meta">{artworkCount} {artworkCount === 1 ? 'artwork' : 'artworks'}</span>
+	</span>
+</Card>
+
+<style>
+	.card { display: block; }
+
+	.frame {
+		position: relative;
+		display: block;
+		aspect-ratio: 3 / 2;
+		overflow: hidden;
+		background: #101013;
+		border: 1px solid var(--hair);
+	}
+
+	.frame.is-empty {
+		background-image: repeating-linear-gradient(
+			-45deg,
+			rgba(236, 231, 221, 0.05) 0 1px,
+			transparent 1px 9px
+		);
+	}
+
+	.layer {
+		position: absolute;
+		inset: 0 0 0 auto;
+		height: 100%;
+		object-fit: cover;
+		filter: saturate(0.75) brightness(0.86);
+		border-left: 1px solid rgba(8, 8, 10, 0.85);
+		transition: transform 600ms cubic-bezier(0.2, 0.7, 0.2, 1), filter 400ms;
+	}
+
+	.layer-0 { left: 0; right: auto; width: 100%; z-index: 1; }
+	.layer-1 { right: 0; width: 46%; z-index: 2; transform: translateX(18%); }
+	.layer-2 { right: 0; width: 30%; z-index: 3; transform: translateX(36%); }
+
+	a.card:hover .layer-1,
+	a.card:hover .layer-2 { transform: translateX(0); }
+	a.card:hover .layer { filter: saturate(1) brightness(1); }
+	a.card:hover .frame { border-color: rgba(236, 231, 221, 0.4); }
+
+	.no-image {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		font-size: 0.75rem;
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		color: var(--muted);
+	}
+
+	.status {
+		position: absolute;
+		top: 0.75rem;
+		left: 0.75rem;
+		z-index: 4;
+		padding: 0.25rem 0.6rem;
+		font-size: 0.62rem;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		backdrop-filter: blur(6px);
+		background: rgba(8, 8, 10, 0.6);
+		border: 1px solid var(--hair);
+	}
+
+	.status.is-live { color: var(--paper); border-color: rgba(236, 231, 221, 0.45); }
+	.status.is-draft { color: var(--seal); border-color: rgba(193, 69, 44, 0.6); }
+
+	.card-body {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding-top: 0.85rem;
+	}
+
+	.card-title { font-size: 1.05rem; letter-spacing: 0.04em; }
+
+	.card-meta {
+		font-size: 0.75rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--muted);
+		white-space: nowrap;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.layer { transition: none; }
+	}
+</style>

--- a/code/src/components/admin/CoverStack.astro
+++ b/code/src/components/admin/CoverStack.astro
@@ -1,52 +1,38 @@
 ---
-// A collection holds artwork rather than an image of its own, so its cover is
-// a fan of member pieces that squares up on hover. Only three layers are
-// styled; COLLECTION_COVER_LAYERS in db/admin.ts caps the input to match.
+// A collection holds artwork rather than an image of its own, so its cover is a
+// fan of member pieces that squares up on hover. Only three layers are styled,
+// so the component enforces that cap itself rather than trusting its caller.
+import CardCaption from './CardCaption.astro';
+import StatusPill, { type StatusTone } from './StatusPill.astro';
+
 interface Props {
 	href?: string | null;
 	name: string;
 	artworkCount: number;
 	coverUrls: string[];
-	status?: { label: string; tone: 'live' | 'draft' } | null;
+	status?: { label: string; tone: StatusTone } | null;
 }
 
 const { href, name, artworkCount, coverUrls, status } = Astro.props;
+const layers = coverUrls.slice(0, 3);
 const Card = href ? 'a' : 'div';
 ---
 <Card class="card" href={href ?? undefined}>
-	<span class:list={['frame', { 'is-empty': coverUrls.length === 0 }]}>
-		{coverUrls.length === 0 ? (
+	<span class:list={['frame', 'stack', { 'is-empty': layers.length === 0 }]}>
+		{layers.length === 0 ? (
 			<span class="no-image">No artwork</span>
 		) : (
-			coverUrls.map((url, index) => <img class={`layer layer-${index}`} src={url} alt="" loading="lazy" />)
+			layers.map((url, index) => <img class={`layer layer-${index}`} src={url} alt="" loading="lazy" />)
 		)}
-		{status && <span class:list={['status', `is-${status.tone}`]}>{status.label}</span>}
+		{status && <StatusPill label={status.label} tone={status.tone} />}
 	</span>
-	<span class="card-body">
-		<span class="card-title">{name}</span>
-		<span class="card-meta">{artworkCount} {artworkCount === 1 ? 'artwork' : 'artworks'}</span>
-	</span>
+	<CardCaption title={name} meta={`${artworkCount} ${artworkCount === 1 ? 'artwork' : 'artworks'}`} />
 </Card>
 
 <style>
 	.card { display: block; }
 
-	.frame {
-		position: relative;
-		display: block;
-		aspect-ratio: 3 / 2;
-		overflow: hidden;
-		background: #101013;
-		border: 1px solid var(--hair);
-	}
-
-	.frame.is-empty {
-		background-image: repeating-linear-gradient(
-			-45deg,
-			rgba(236, 231, 221, 0.05) 0 1px,
-			transparent 1px 9px
-		);
-	}
+	.stack { aspect-ratio: 3 / 2; }
 
 	.layer {
 		position: absolute;
@@ -65,53 +51,6 @@ const Card = href ? 'a' : 'div';
 	a.card:hover .layer-1,
 	a.card:hover .layer-2 { transform: translateX(0); }
 	a.card:hover .layer { filter: saturate(1) brightness(1); }
-	a.card:hover .frame { border-color: rgba(236, 231, 221, 0.4); }
-
-	.no-image {
-		position: absolute;
-		inset: 0;
-		display: grid;
-		place-items: center;
-		font-size: 0.75rem;
-		letter-spacing: 0.2em;
-		text-transform: uppercase;
-		color: var(--muted);
-	}
-
-	.status {
-		position: absolute;
-		top: 0.75rem;
-		left: 0.75rem;
-		z-index: 4;
-		padding: 0.25rem 0.6rem;
-		font-size: 0.62rem;
-		letter-spacing: 0.18em;
-		text-transform: uppercase;
-		backdrop-filter: blur(6px);
-		background: rgba(8, 8, 10, 0.6);
-		border: 1px solid var(--hair);
-	}
-
-	.status.is-live { color: var(--paper); border-color: rgba(236, 231, 221, 0.45); }
-	.status.is-draft { color: var(--seal); border-color: rgba(193, 69, 44, 0.6); }
-
-	.card-body {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: 1rem;
-		padding-top: 0.85rem;
-	}
-
-	.card-title { font-size: 1.05rem; letter-spacing: 0.04em; }
-
-	.card-meta {
-		font-size: 0.75rem;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
-		color: var(--muted);
-		white-space: nowrap;
-	}
 
 	@media (prefers-reduced-motion: reduce) {
 		.layer { transition: none; }

--- a/code/src/components/admin/CreateAction.astro
+++ b/code/src/components/admin/CreateAction.astro
@@ -5,12 +5,11 @@ interface Props {
 	href: string;
 	title: string;
 	note: string;
-	delay?: number;
 }
 
-const { href, title, note, delay } = Astro.props;
+const { href, title, note } = Astro.props;
 ---
-<a class="action reveal" href={href} style={delay === undefined ? undefined : `animation-delay: ${delay}ms`}>
+<a class="action" href={href}>
 	<span class="seal" aria-hidden="true">+</span>
 	<span class="action-copy">
 		<span class="action-title">{title}</span>
@@ -79,17 +78,8 @@ const { href, title, note, delay } = Astro.props;
 		color: var(--seal);
 	}
 
-	.reveal {
-		animation: rise 700ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
-	}
-
-	@keyframes rise {
-		from { opacity: 0; transform: translateY(1.25rem); }
-		to { opacity: 1; transform: none; }
-	}
 
 	@media (prefers-reduced-motion: reduce) {
-		.reveal { animation: none; }
 		.seal, .action-arrow { transition: none; }
 	}
 </style>

--- a/code/src/components/admin/CreateAction.astro
+++ b/code/src/components/admin/CreateAction.astro
@@ -1,0 +1,95 @@
+---
+// The console's primary call to action: a seal, what it makes, and what the
+// form will ask for.
+interface Props {
+	href: string;
+	title: string;
+	note: string;
+	delay?: number;
+}
+
+const { href, title, note, delay } = Astro.props;
+---
+<a class="action reveal" href={href} style={delay === undefined ? undefined : `animation-delay: ${delay}ms`}>
+	<span class="seal" aria-hidden="true">+</span>
+	<span class="action-copy">
+		<span class="action-title">{title}</span>
+		<span class="action-note">{note}</span>
+	</span>
+	<span class="action-arrow" aria-hidden="true">&rarr;</span>
+</a>
+
+<style>
+	.action {
+		display: flex;
+		align-items: center;
+		gap: 1.25rem;
+		padding: clamp(1.5rem, 3vw, 2.25rem);
+		background: rgba(8, 8, 10, 0.75);
+		transition: background 250ms;
+	}
+
+	.action:hover {
+		background: rgba(193, 69, 44, 0.09);
+	}
+
+	.seal {
+		flex: none;
+		display: grid;
+		place-items: center;
+		width: 3rem;
+		height: 3rem;
+		font-size: 1.5rem;
+		line-height: 1;
+		color: var(--paper);
+		background: var(--seal);
+		transition: transform 250ms cubic-bezier(0.2, 0.7, 0.2, 1);
+	}
+
+	.action:hover .seal {
+		transform: rotate(-6deg) scale(1.06);
+	}
+
+	.action-copy {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.action-title {
+		font-size: 1.4rem;
+		text-transform: uppercase;
+		letter-spacing: 0.16em;
+	}
+
+	.action-note {
+		font-size: 0.85rem;
+		color: var(--muted);
+	}
+
+	.action-arrow {
+		margin-left: auto;
+		font-size: 1.4rem;
+		color: var(--muted);
+		transition: transform 250ms, color 250ms;
+	}
+
+	.action:hover .action-arrow {
+		transform: translateX(0.35rem);
+		color: var(--seal);
+	}
+
+	.reveal {
+		animation: rise 700ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
+	}
+
+	@keyframes rise {
+		from { opacity: 0; transform: translateY(1.25rem); }
+		to { opacity: 1; transform: none; }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.reveal { animation: none; }
+		.seal, .action-arrow { transition: none; }
+	}
+</style>

--- a/code/src/components/admin/EmptyState.astro
+++ b/code/src/components/admin/EmptyState.astro
@@ -1,0 +1,32 @@
+---
+// The prompt shown where a section has nothing yet. With an href it is the
+// section's create action; without one it is a plain statement.
+interface Props {
+	href?: string | null;
+	label: string;
+}
+
+const { href, label } = Astro.props;
+const Tag = href ? 'a' : 'p';
+---
+<Tag class:list={['empty', { 'is-static': !href }]} href={href ?? undefined}>{label}</Tag>
+
+<style>
+	.empty {
+		display: block;
+		margin-top: 1.75rem;
+		padding: 2.5rem;
+		border: 1px dashed var(--hair);
+		font-size: 0.9rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--muted);
+		text-align: center;
+		transition: border-color 200ms, color 200ms;
+	}
+
+	a.empty:hover {
+		border-color: var(--seal);
+		color: var(--paper);
+	}
+</style>

--- a/code/src/components/admin/MediaCard.astro
+++ b/code/src/components/admin/MediaCard.astro
@@ -1,0 +1,143 @@
+---
+// One catalog item: a framed image, a status pill, a title, and one line of
+// meta. An item with nowhere to go renders as a div rather than a dead link.
+interface Props {
+	href?: string | null;
+	title: string;
+	meta?: string | null;
+	metaTone?: 'default' | 'seal';
+	imageUrl?: string | null;
+	imageAlt?: string;
+	placeholder?: string;
+	shape?: 'portrait' | 'landscape';
+	status?: { label: string; tone: 'live' | 'draft' | 'sold' } | null;
+}
+
+const {
+	href,
+	title,
+	meta,
+	metaTone = 'default',
+	imageUrl,
+	imageAlt = '',
+	placeholder = 'No image',
+	shape = 'portrait',
+	status,
+} = Astro.props;
+
+const Card = href ? 'a' : 'div';
+---
+<Card class="card" href={href ?? undefined}>
+	<span class:list={['frame', shape, { 'is-empty': !imageUrl }]}>
+		{imageUrl ? (
+			<img src={imageUrl} alt={imageAlt} loading="lazy" />
+		) : (
+			<span class="no-image">{placeholder}</span>
+		)}
+		{status && <span class:list={['status', `is-${status.tone}`]}>{status.label}</span>}
+	</span>
+	<span class="card-body">
+		<span class="card-title">{title}</span>
+		{meta && <span class:list={['card-meta', { seal: metaTone === 'seal' }]}>{meta}</span>}
+	</span>
+</Card>
+
+<style>
+	.card {
+		display: block;
+	}
+
+	.frame {
+		position: relative;
+		display: block;
+		overflow: hidden;
+		background: #101013;
+		border: 1px solid var(--hair);
+	}
+
+	.portrait { aspect-ratio: 4 / 5; }
+	.landscape { aspect-ratio: 3 / 2; }
+
+	/* An empty frame is common for posts, which usually carry no cover.
+	   Hatching reads as a prepared surface rather than a hole in the page. */
+	.frame.is-empty {
+		background-image: repeating-linear-gradient(
+			-45deg,
+			rgba(236, 231, 221, 0.05) 0 1px,
+			transparent 1px 9px
+		);
+	}
+
+	.frame img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		filter: saturate(0.75) brightness(0.86);
+		transition: transform 600ms cubic-bezier(0.2, 0.7, 0.2, 1), filter 400ms;
+	}
+
+	a.card:hover .frame img {
+		transform: scale(1.04);
+		filter: saturate(1) brightness(1);
+	}
+
+	a.card:hover .frame {
+		border-color: rgba(236, 231, 221, 0.4);
+	}
+
+	.no-image {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		font-size: 0.75rem;
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		color: var(--muted);
+	}
+
+	.status {
+		position: absolute;
+		top: 0.75rem;
+		left: 0.75rem;
+		z-index: 4;
+		padding: 0.25rem 0.6rem;
+		font-size: 0.62rem;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		backdrop-filter: blur(6px);
+		background: rgba(8, 8, 10, 0.6);
+		border: 1px solid var(--hair);
+	}
+
+	.status.is-live { color: var(--paper); border-color: rgba(236, 231, 221, 0.45); }
+	.status.is-draft { color: var(--seal); border-color: rgba(193, 69, 44, 0.6); }
+	.status.is-sold { color: rgba(236, 231, 221, 0.5); }
+
+	.card-body {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding-top: 0.85rem;
+	}
+
+	.card-title {
+		font-size: 1.05rem;
+		letter-spacing: 0.04em;
+	}
+
+	.card-meta {
+		font-size: 0.75rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--muted);
+		white-space: nowrap;
+	}
+
+	.card-meta.seal { color: var(--seal); }
+
+	@media (prefers-reduced-motion: reduce) {
+		.frame img { transition: none; }
+	}
+</style>

--- a/code/src/components/admin/MediaCard.astro
+++ b/code/src/components/admin/MediaCard.astro
@@ -1,6 +1,11 @@
 ---
-// One catalog item: a framed image, a status pill, a title, and one line of
-// meta. An item with nowhere to go renders as a div rather than a dead link.
+// One catalog item: a framed image, a status pill, and its caption. An item
+// with nowhere to go renders as a div rather than a dead link. The frame,
+// hatching and placeholder come from ConsoleShell so every card type shares
+// one chrome.
+import CardCaption from './CardCaption.astro';
+import StatusPill, { type StatusTone } from './StatusPill.astro';
+
 interface Props {
 	href?: string | null;
 	title: string;
@@ -10,7 +15,7 @@ interface Props {
 	imageAlt?: string;
 	placeholder?: string;
 	shape?: 'portrait' | 'landscape';
-	status?: { label: string; tone: 'live' | 'draft' | 'sold' } | null;
+	status?: { label: string; tone: StatusTone } | null;
 }
 
 const {
@@ -34,39 +39,16 @@ const Card = href ? 'a' : 'div';
 		) : (
 			<span class="no-image">{placeholder}</span>
 		)}
-		{status && <span class:list={['status', `is-${status.tone}`]}>{status.label}</span>}
+		{status && <StatusPill label={status.label} tone={status.tone} />}
 	</span>
-	<span class="card-body">
-		<span class="card-title">{title}</span>
-		{meta && <span class:list={['card-meta', { seal: metaTone === 'seal' }]}>{meta}</span>}
-	</span>
+	<CardCaption title={title} meta={meta} metaTone={metaTone} />
 </Card>
 
 <style>
-	.card {
-		display: block;
-	}
-
-	.frame {
-		position: relative;
-		display: block;
-		overflow: hidden;
-		background: #101013;
-		border: 1px solid var(--hair);
-	}
+	.card { display: block; }
 
 	.portrait { aspect-ratio: 4 / 5; }
 	.landscape { aspect-ratio: 3 / 2; }
-
-	/* An empty frame is common for posts, which usually carry no cover.
-	   Hatching reads as a prepared surface rather than a hole in the page. */
-	.frame.is-empty {
-		background-image: repeating-linear-gradient(
-			-45deg,
-			rgba(236, 231, 221, 0.05) 0 1px,
-			transparent 1px 9px
-		);
-	}
 
 	.frame img {
 		width: 100%;
@@ -80,62 +62,6 @@ const Card = href ? 'a' : 'div';
 		transform: scale(1.04);
 		filter: saturate(1) brightness(1);
 	}
-
-	a.card:hover .frame {
-		border-color: rgba(236, 231, 221, 0.4);
-	}
-
-	.no-image {
-		position: absolute;
-		inset: 0;
-		display: grid;
-		place-items: center;
-		font-size: 0.75rem;
-		letter-spacing: 0.2em;
-		text-transform: uppercase;
-		color: var(--muted);
-	}
-
-	.status {
-		position: absolute;
-		top: 0.75rem;
-		left: 0.75rem;
-		z-index: 4;
-		padding: 0.25rem 0.6rem;
-		font-size: 0.62rem;
-		letter-spacing: 0.18em;
-		text-transform: uppercase;
-		backdrop-filter: blur(6px);
-		background: rgba(8, 8, 10, 0.6);
-		border: 1px solid var(--hair);
-	}
-
-	.status.is-live { color: var(--paper); border-color: rgba(236, 231, 221, 0.45); }
-	.status.is-draft { color: var(--seal); border-color: rgba(193, 69, 44, 0.6); }
-	.status.is-sold { color: rgba(236, 231, 221, 0.5); }
-
-	.card-body {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: 1rem;
-		padding-top: 0.85rem;
-	}
-
-	.card-title {
-		font-size: 1.05rem;
-		letter-spacing: 0.04em;
-	}
-
-	.card-meta {
-		font-size: 0.75rem;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
-		color: var(--muted);
-		white-space: nowrap;
-	}
-
-	.card-meta.seal { color: var(--seal); }
 
 	@media (prefers-reduced-motion: reduce) {
 		.frame img { transition: none; }

--- a/code/src/components/admin/StatusPill.astro
+++ b/code/src/components/admin/StatusPill.astro
@@ -1,0 +1,34 @@
+---
+// The state badge both card types wear. It sits over user-uploaded artwork, so
+// the ground is near-opaque and every tone carries readable type: the seal
+// survives only as a border, never as the text colour.
+export type StatusTone = 'live' | 'draft' | 'sold';
+
+interface Props {
+	label: string;
+	tone: StatusTone;
+}
+
+const { label, tone } = Astro.props;
+---
+<span class:list={['status', `is-${tone}`]}>{label}</span>
+
+<style>
+	.status {
+		position: absolute;
+		top: 0.75rem;
+		left: 0.75rem;
+		z-index: 4;
+		padding: 0.25rem 0.6rem;
+		font-size: 0.68rem;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		color: var(--paper);
+		background: rgba(8, 8, 10, 0.88);
+		border: 1px solid var(--hair);
+	}
+
+	.status.is-live { border-color: rgba(236, 231, 221, 0.45); }
+	.status.is-draft { border-color: rgba(193, 69, 44, 0.85); }
+	.status.is-sold { border-color: rgba(236, 231, 221, 0.25); }
+</style>

--- a/code/src/db/admin.ts
+++ b/code/src/db/admin.ts
@@ -222,14 +222,6 @@ export async function getAdminArtwork(env: Env, slug: string) {
 // Dashboard shapes. The dashboard is the only admin surface that reads every
 // entity at once, so it keeps its own narrow projections instead of loading the
 // full rows the editors need.
-export interface DashboardArtwork {
-	slug: string;
-	title: string;
-	year: number | null;
-	publishedAt: Date | null;
-	imageUrl: string | null;
-}
-
 export interface DashboardCollection {
 	slug: string;
 	name: string;
@@ -254,7 +246,7 @@ export interface DashboardTally {
 }
 
 export interface AdminDashboard {
-	artworks: { recent: DashboardArtwork[]; tally: DashboardTally };
+	artworks: { recent: AdminArtworkCard[]; tally: DashboardTally };
 	collections: { recent: DashboardCollection[]; tally: DashboardTally };
 	store: {
 		recent: DashboardProduct[];
@@ -263,6 +255,8 @@ export interface AdminDashboard {
 }
 
 const DASHBOARD_LIMIT = 3;
+// CoverStack.astro styles exactly three fanned layers.
+const COLLECTION_COVER_LAYERS = 3;
 
 // sum() over zero rows is NULL in SQLite, and an ungrouped aggregate always
 // returns a row, so every conditional count needs its own coalesce.
@@ -271,10 +265,85 @@ const publishedTally = (column: typeof artworks.publishedAt | typeof collections
 	published: sql<number>`coalesce(sum(case when ${column} is not null then 1 else 0 end), 0)`,
 });
 
-// One artwork can carry several images; the dashboard needs exactly one, and it
-// must agree with the cover the public catalog shows.
-function defaultImageOf(images: { url: string; isDefault: boolean }[]) {
-	return images.find((image) => image.isDefault)?.url ?? images[0]?.url ?? null;
+// admin-input.ts rejects a second default and promotes the first image when no
+// image is flagged, so an artwork with images has exactly one default row.
+// Joining on that flag returns one row per artwork, which is why nothing below
+// folds images together in JavaScript.
+const onDefaultImage = (artworkId: typeof artworks.id | typeof artworksToCollections.artworkId) =>
+	and(eq(artworkImages.artworkId, artworkId), eq(artworkImages.isDefault, true));
+
+const artworkCardColumns = {
+	slug: artworks.slug,
+	title: artworks.title,
+	year: artworks.year,
+	publishedAt: artworks.publishedAt,
+	imageUrl: artworkImages.url,
+};
+
+export type AdminArtworkCard = {
+	slug: string;
+	title: string;
+	year: number | null;
+	publishedAt: Date | null;
+	imageUrl: string | null;
+};
+
+type CollectionRow = typeof collections.$inferSelect;
+type MemberRow = { collectionId: number; isCover: boolean; url: string | null };
+
+// A collection has no image of its own, so its cover comes from the artwork it
+// holds, with the collection's chosen cover piece promoted to the front.
+async function withCovers(db: Database, rows: CollectionRow[]): Promise<DashboardCollection[]> {
+	const collectionIds = rows.map((collection) => collection.id);
+	const members: MemberRow[] = collectionIds.length
+		? await db
+				.select({
+					collectionId: artworksToCollections.collectionId,
+					isCover: artworksToCollections.isDefaultForCollection,
+					url: artworkImages.url,
+				})
+				.from(artworksToCollections)
+				.leftJoin(artworkImages, onDefaultImage(artworksToCollections.artworkId))
+				.where(inArray(artworksToCollections.collectionId, collectionIds))
+		: [];
+
+	const byCollection = new Map<number, MemberRow[]>();
+	for (const member of members) {
+		const bucket = byCollection.get(member.collectionId) ?? [];
+		bucket.push(member);
+		byCollection.set(member.collectionId, bucket);
+	}
+
+	return rows.map((collection) => {
+		const memberRows = byCollection.get(collection.id) ?? [];
+		return {
+			slug: collection.slug,
+			name: collection.name,
+			publishedAt: collection.publishedAt,
+			artworkCount: memberRows.length,
+			coverUrls: memberRows
+				.slice()
+				.sort((left, right) => Number(right.isCover) - Number(left.isCover))
+				.map((member) => member.url)
+				.filter((url): url is string => url !== null)
+				.slice(0, COLLECTION_COVER_LAYERS),
+		};
+	});
+}
+
+// The list pages show every row with its cover; the dashboard shows the newest
+// few. Both read the same shapes.
+export async function getAdminArtworkCards(env: Env, db = getDb(env)): Promise<AdminArtworkCard[]> {
+	return db
+		.select(artworkCardColumns)
+		.from(artworks)
+		.leftJoin(artworkImages, onDefaultImage(artworks.id))
+		.orderBy(artworks.title);
+}
+
+export async function getAdminCollectionCards(env: Env, db = getDb(env)): Promise<DashboardCollection[]> {
+	const rows = await db.select().from(collections).orderBy(collections.name);
+	return withCovers(db, rows);
 }
 
 export async function getAdminDashboard(env: Env, db = getDb(env)): Promise<AdminDashboard> {
@@ -282,7 +351,12 @@ export async function getAdminDashboard(env: Env, db = getDb(env)): Promise<Admi
 		await Promise.all([
 			// created_at holds whole seconds, so rows written in the same second
 			// tie; the autoincrement id breaks the tie in insertion order.
-			db.select().from(artworks).orderBy(desc(artworks.createdAt), desc(artworks.id)).limit(DASHBOARD_LIMIT),
+			db
+				.select(artworkCardColumns)
+				.from(artworks)
+				.leftJoin(artworkImages, onDefaultImage(artworks.id))
+				.orderBy(desc(artworks.createdAt), desc(artworks.id))
+				.limit(DASHBOARD_LIMIT),
 			db.select().from(collections).orderBy(desc(collections.createdAt), desc(collections.id)).limit(DASHBOARD_LIMIT),
 			db.select().from(products).orderBy(desc(products.createdAt), desc(products.id)).limit(DASHBOARD_LIMIT),
 			db.select(publishedTally(artworks.publishedAt)).from(artworks),
@@ -296,30 +370,13 @@ export async function getAdminDashboard(env: Env, db = getDb(env)): Promise<Admi
 				.from(products),
 		]);
 
-	const artworkIds = artworkRows.map((artwork) => artwork.id);
-	const collectionIds = collectionRows.map((collection) => collection.id);
 	// A product is edited through its artwork, so each card needs the artwork slug.
 	const productArtworkIds = productRows
 		.map((product) => product.artworkId)
 		.filter((id): id is number => id !== null);
 
-	const [imageRows, membershipRows, productArtworkRows] = await Promise.all([
-		artworkIds.length
-			? db.select().from(artworkImages).where(inArray(artworkImages.artworkId, artworkIds))
-			: Promise.resolve([] as (typeof artworkImages.$inferSelect)[]),
-		collectionIds.length
-			? db
-					.select({
-						collectionId: artworksToCollections.collectionId,
-						artworkId: artworksToCollections.artworkId,
-						isCover: artworksToCollections.isDefaultForCollection,
-						url: artworkImages.url,
-						isDefault: artworkImages.isDefault,
-					})
-					.from(artworksToCollections)
-					.leftJoin(artworkImages, eq(artworkImages.artworkId, artworksToCollections.artworkId))
-					.where(inArray(artworksToCollections.collectionId, collectionIds))
-			: Promise.resolve([] as { collectionId: number; artworkId: number; isCover: boolean; url: string | null; isDefault: boolean | null }[]),
+	const [recentCollections, productArtworkRows] = await Promise.all([
+		withCovers(db, collectionRows),
 		productArtworkIds.length
 			? db
 					.select({ id: artworks.id, slug: artworks.slug })
@@ -330,55 +387,13 @@ export async function getAdminDashboard(env: Env, db = getDb(env)): Promise<Admi
 
 	const artworkSlugById = new Map(productArtworkRows.map((row) => [row.id, row.slug]));
 
-	const imagesByArtwork = new Map<number, { url: string; isDefault: boolean }[]>();
-	for (const image of imageRows) {
-		const bucket = imagesByArtwork.get(image.artworkId) ?? [];
-		bucket.push({ url: image.url, isDefault: image.isDefault });
-		imagesByArtwork.set(image.artworkId, bucket);
-	}
-
-	// The join fans out one row per (artwork, image) pair, so members are folded
-	// back per artwork before the cover artwork is promoted to the front.
-	const membersByCollection = new Map<
-		number,
-		Map<number, { isCover: boolean; images: { url: string; isDefault: boolean }[] }>
-	>();
-	for (const row of membershipRows) {
-		const members = membersByCollection.get(row.collectionId) ?? new Map();
-		const member = members.get(row.artworkId) ?? { isCover: false, images: [] };
-		member.isCover = member.isCover || row.isCover;
-		if (row.url) member.images.push({ url: row.url, isDefault: row.isDefault ?? false });
-		members.set(row.artworkId, member);
-		membersByCollection.set(row.collectionId, members);
-	}
-
 	return {
 		artworks: {
-			recent: artworkRows.map((artwork) => ({
-				slug: artwork.slug,
-				title: artwork.title,
-				year: artwork.year,
-				publishedAt: artwork.publishedAt,
-				imageUrl: defaultImageOf(imagesByArtwork.get(artwork.id) ?? []),
-			})),
+			recent: artworkRows,
 			tally: artworkTally[0] ?? { total: 0, published: 0 },
 		},
 		collections: {
-			recent: collectionRows.map((collection) => {
-				const members = Array.from(membersByCollection.get(collection.id)?.values() ?? []);
-				const coverUrls = members
-					.sort((left, right) => Number(right.isCover) - Number(left.isCover))
-					.map((member) => defaultImageOf(member.images))
-					.filter((url): url is string => url !== null)
-					.slice(0, DASHBOARD_LIMIT);
-				return {
-					slug: collection.slug,
-					name: collection.name,
-					publishedAt: collection.publishedAt,
-					artworkCount: members.length,
-					coverUrls,
-				};
-			}),
+			recent: recentCollections,
 			tally: collectionTally[0] ?? { total: 0, published: 0 },
 		},
 		store: {

--- a/code/src/pages/admin.astro
+++ b/code/src/pages/admin.astro
@@ -1,6 +1,12 @@
 ---
 import { getCollection } from 'astro:content';
-import BaseLayout from '../layouts/BaseLayout.astro';
+import CardGrid from '../components/admin/CardGrid.astro';
+import ConsoleSection from '../components/admin/ConsoleSection.astro';
+import ConsoleShell from '../components/admin/ConsoleShell.astro';
+import CoverStack from '../components/admin/CoverStack.astro';
+import CreateAction from '../components/admin/CreateAction.astro';
+import EmptyState from '../components/admin/EmptyState.astro';
+import MediaCard from '../components/admin/MediaCard.astro';
 import { getAdminDashboard } from '../db/admin';
 import { requireAdminPage } from '../lib/admin-guard';
 import { getPostPublishedDate, isPublishedPost } from '../lib/post-content';
@@ -48,313 +54,145 @@ const postTypeLabels: Record<string, string> = {
 	behind_the_scenes: 'Behind the scenes',
 	general: 'General',
 };
+
+const draftTally = (tally: { total: number; published: number }) =>
+	`${tally.total} total · ${tally.published} published · ${tally.total - tally.published} draft`;
 ---
-<BaseLayout title="Admin — EONMUN" description="EONMUN studio console.">
-	<div class="console">
-		<div class="ground" aria-hidden="true"></div>
-		<div class="wrap">
-			<header class="masthead">
-				<div>
-					<p class="eyebrow">Studio console</p>
-					<h1 class="title">Admin</h1>
-				</div>
-				<div class="identity">
-					<span class="email">{session.user.email}</span>
-					<a class="signout" href="/api/auth/signout">Sign out</a>
-				</div>
-			</header>
-
-			<div class="actions">
-				<a class="action reveal" href="/admin/artworks/new" style="animation-delay: 60ms">
-					<span class="seal" aria-hidden="true">+</span>
-					<span class="action-copy">
-						<span class="action-title">New artwork</span>
-						<span class="action-note">Images, dimensions, collections, private price.</span>
-					</span>
-					<span class="action-arrow" aria-hidden="true">&rarr;</span>
-				</a>
-				<a class="action reveal" href="/admin/collections/new" style="animation-delay: 120ms">
-					<span class="seal" aria-hidden="true">+</span>
-					<span class="action-copy">
-						<span class="action-title">New collection</span>
-						<span class="action-note">Group artwork and choose the cover piece.</span>
-					</span>
-					<span class="action-arrow" aria-hidden="true">&rarr;</span>
-				</a>
-			</div>
-
-			<section class="entity reveal" style="animation-delay: 180ms">
-				<div class="entity-head">
-					<h2><span class="index">01</span> Artwork</h2>
-					<p class="tally">
-						{artworks.tally.total} total &middot; {artworks.tally.published} published &middot;
-						{artworks.tally.total - artworks.tally.published} draft
-					</p>
-					<div class="entity-links">
-						<a class="ghost" href="/admin/artworks/new">New</a>
-						<a class="ghost" href="/admin/artworks">All artwork &rarr;</a>
-					</div>
-				</div>
-				{artworks.recent.length === 0 ? (
-					<a class="empty" href="/admin/artworks/new">No artwork yet. Add the first piece &rarr;</a>
-				) : (
-					<ul class="grid">
-						{artworks.recent.map((artwork) => (
-							<li>
-								<a class="card" href={`/admin/artworks/${artwork.slug}`}>
-									<span class="frame portrait">
-										{artwork.imageUrl ? (
-											<img src={artwork.imageUrl} alt="" loading="lazy" />
-										) : (
-											<span class="no-image">No image</span>
-										)}
-										<span class:list={['status', artwork.publishedAt ? 'is-live' : 'is-draft']}>
-											{artwork.publishedAt ? 'Published' : 'Draft'}
-										</span>
-									</span>
-									<span class="card-body">
-										<span class="card-title">{artwork.title}</span>
-										<span class="card-meta">{artwork.year ?? 'Year unset'}</span>
-									</span>
-								</a>
-							</li>
-						))}
-					</ul>
-				)}
-			</section>
-
-			<section class="entity reveal" style="animation-delay: 240ms">
-				<div class="entity-head">
-					<h2><span class="index">02</span> Collections</h2>
-					<p class="tally">
-						{collections.tally.total} total &middot; {collections.tally.published} published &middot;
-						{collections.tally.total - collections.tally.published} draft
-					</p>
-					<div class="entity-links">
-						<a class="ghost" href="/admin/collections/new">New</a>
-						<a class="ghost" href="/admin/collections">All collections &rarr;</a>
-					</div>
-				</div>
-				{collections.recent.length === 0 ? (
-					<a class="empty" href="/admin/collections/new">No collections yet. Group your first pieces &rarr;</a>
-				) : (
-					<ul class="grid">
-						{collections.recent.map((collection) => (
-							<li>
-								<a class="card" href={`/admin/collections/${collection.slug}`}>
-									<span class="frame stack">
-										{collection.coverUrls.length === 0 ? (
-											<span class="no-image">No artwork</span>
-										) : (
-											collection.coverUrls.map((url, index) => (
-												<img class={`layer layer-${index}`} src={url} alt="" loading="lazy" />
-											))
-										)}
-										<span class:list={['status', collection.publishedAt ? 'is-live' : 'is-draft']}>
-											{collection.publishedAt ? 'Published' : 'Draft'}
-										</span>
-									</span>
-									<span class="card-body">
-										<span class="card-title">{collection.name}</span>
-										<span class="card-meta">
-											{collection.artworkCount} {collection.artworkCount === 1 ? 'artwork' : 'artworks'}
-										</span>
-									</span>
-								</a>
-							</li>
-						))}
-					</ul>
-				)}
-			</section>
-
-			<section class="entity reveal" style="animation-delay: 300ms">
-				<div class="entity-head">
-					<h2><span class="index">03</span> Private sales</h2>
-					<p class="tally">
-						{store.tally.total} listed &middot; {store.tally.available} available &middot; {store.tally.sold} sold
-					</p>
-					<div class="entity-links">
-						<a class="ghost" href="/admin/artworks/new">New</a>
-						<a class="ghost" href="/admin/artworks">All artwork &rarr;</a>
-					</div>
-				</div>
-				{store.recent.length === 0 ? (
-					<a class="empty" href="/admin/artworks/new">Nothing listed. Give an artwork a price &rarr;</a>
-				) : (
-					<ul class="grid">
-						{store.recent.map((product) => (
-							<li>
-								<a
-									class="card"
-									href={product.artworkSlug ? `/admin/artworks/${product.artworkSlug}` : '/admin/artworks'}
-								>
-									<span class="frame landscape">
-										{product.imageUrl ? (
-											<img src={product.imageUrl} alt="" loading="lazy" />
-										) : (
-											<span class="no-image">No image</span>
-										)}
-										<span
-											class:list={[
-												'status',
-												product.soldAt ? 'is-sold' : (product.quantity ?? 0) > 0 ? 'is-live' : 'is-draft',
-											]}
-										>
-											{product.soldAt ? 'Sold' : (product.quantity ?? 0) > 0 ? 'Available' : 'Not for sale'}
-										</span>
-									</span>
-									<span class="card-body">
-										<span class="card-title">{product.name}</span>
-										<span class="card-meta price">{formatPrice(product.priceCents)}</span>
-									</span>
-								</a>
-							</li>
-						))}
-					</ul>
-				)}
-			</section>
-
-			<section class="entity reveal" style="animation-delay: 360ms">
-				<div class="entity-head">
-					<h2><span class="index">04</span> Posts</h2>
-					<p class="tally">{postEntries.length} written &middot; edited in the repository</p>
-					<div class="entity-links">
-						<a class="ghost" href="/posts">All posts &rarr;</a>
-					</div>
-				</div>
-				{posts.length === 0 ? (
-					<p class="empty is-static">No posts yet.</p>
-				) : (
-					<ul class="grid">
-						{posts.map((post) => {
-							const Card = post.published ? 'a' : 'div';
-							return (
-								<li>
-									<Card class="card" href={post.published ? `/posts/${post.slug}` : undefined}>
-										<span class="frame landscape">
-											{post.coverImageUrl ? (
-												<img src={post.coverImageUrl} alt="" loading="lazy" />
-											) : (
-												<span class="no-image">{postTypeLabels[post.postType] ?? 'Post'}</span>
-											)}
-											{!post.published && (
-												<span class="status is-draft">{post.date ? 'Scheduled' : 'Draft'}</span>
-											)}
-										</span>
-										<span class="card-body">
-											<span class="card-title">{post.title}</span>
-											<span class="card-meta">{formatDate(post.date) ?? 'Unscheduled'}</span>
-										</span>
-									</Card>
-								</li>
-							);
-						})}
-					</ul>
-				)}
-			</section>
-		</div>
+<ConsoleShell title="Admin — EONMUN" heading="Admin" email={session.user.email}>
+	<div class="actions">
+		<CreateAction
+			href="/admin/artworks/new"
+			title="New artwork"
+			note="Images, dimensions, collections, private price."
+			delay={60}
+		/>
+		<CreateAction
+			href="/admin/collections/new"
+			title="New collection"
+			note="Group artwork and choose the cover piece."
+			delay={120}
+		/>
 	</div>
-</BaseLayout>
 
-<style is:global>
-	/* The console commits to dark on this route only, so the footer and any
-	   overscroll stay in the same room as the page. */
-	body:has(.console) {
-		background: #050506;
-		color: #ece7dd;
-	}
-</style>
+	<ConsoleSection
+		index="01"
+		title="Artwork"
+		tally={draftTally(artworks.tally)}
+		links={[{ href: '/admin/artworks/new', label: 'New' }, { href: '/admin/artworks', label: 'All artwork →' }]}
+		delay={180}
+	>
+		{artworks.recent.length === 0 ? (
+			<EmptyState href="/admin/artworks/new" label="No artwork yet. Add the first piece →" />
+		) : (
+			<CardGrid>
+				{artworks.recent.map((artwork) => (
+					<li>
+						<MediaCard
+							href={`/admin/artworks/${artwork.slug}`}
+							title={artwork.title}
+							meta={artwork.year ? String(artwork.year) : 'Year unset'}
+							imageUrl={artwork.imageUrl}
+							status={{
+								label: artwork.publishedAt ? 'Published' : 'Draft',
+								tone: artwork.publishedAt ? 'live' : 'draft',
+							}}
+						/>
+					</li>
+				))}
+			</CardGrid>
+		)}
+	</ConsoleSection>
+
+	<ConsoleSection
+		index="02"
+		title="Collections"
+		tally={draftTally(collections.tally)}
+		links={[{ href: '/admin/collections/new', label: 'New' }, { href: '/admin/collections', label: 'All collections →' }]}
+		delay={240}
+	>
+		{collections.recent.length === 0 ? (
+			<EmptyState href="/admin/collections/new" label="No collections yet. Group your first pieces →" />
+		) : (
+			<CardGrid>
+				{collections.recent.map((collection) => (
+					<li>
+						<CoverStack
+							href={`/admin/collections/${collection.slug}`}
+							name={collection.name}
+							artworkCount={collection.artworkCount}
+							coverUrls={collection.coverUrls}
+							status={{
+								label: collection.publishedAt ? 'Published' : 'Draft',
+								tone: collection.publishedAt ? 'live' : 'draft',
+							}}
+						/>
+					</li>
+				))}
+			</CardGrid>
+		)}
+	</ConsoleSection>
+
+	<ConsoleSection
+		index="03"
+		title="Private sales"
+		tally={`${store.tally.total} listed · ${store.tally.available} available · ${store.tally.sold} sold`}
+		links={[{ href: '/admin/artworks/new', label: 'New artwork' }, { href: '/admin/artworks', label: 'All artwork →' }]}
+		delay={300}
+	>
+		{store.recent.length === 0 ? (
+			<EmptyState href="/admin/artworks/new" label="Nothing listed. Give an artwork a price →" />
+		) : (
+			<CardGrid>
+				{store.recent.map((product) => (
+					<li>
+						<MediaCard
+							href={product.artworkSlug ? `/admin/artworks/${product.artworkSlug}` : '/admin/artworks'}
+							title={product.name}
+							meta={formatPrice(product.priceCents)}
+							metaTone="seal"
+							shape="landscape"
+							imageUrl={product.imageUrl}
+							status={{
+								label: product.soldAt ? 'Sold' : (product.quantity ?? 0) > 0 ? 'Available' : 'Not for sale',
+								tone: product.soldAt ? 'sold' : (product.quantity ?? 0) > 0 ? 'live' : 'draft',
+							}}
+						/>
+					</li>
+				))}
+			</CardGrid>
+		)}
+	</ConsoleSection>
+
+	<ConsoleSection
+		index="04"
+		title="Posts"
+		tally={`${postEntries.length} written · edited in the repository`}
+		links={[{ href: '/posts', label: 'All posts →' }]}
+		delay={360}
+	>
+		{posts.length === 0 ? (
+			<EmptyState label="No posts yet." />
+		) : (
+			<CardGrid>
+				{posts.map((post) => (
+					<li>
+						<MediaCard
+							href={post.published ? `/posts/${post.slug}` : null}
+							title={post.title}
+							meta={formatDate(post.date) ?? 'Unscheduled'}
+							shape="landscape"
+							imageUrl={post.coverImageUrl}
+							placeholder={postTypeLabels[post.postType] ?? 'Post'}
+							status={post.published ? null : { label: post.date ? 'Scheduled' : 'Draft', tone: 'draft' }}
+						/>
+					</li>
+				))}
+			</CardGrid>
+		)}
+	</ConsoleSection>
+</ConsoleShell>
 
 <style>
-	/* The console commits to dark: the shared navbar draws its wordmark in white,
-	   and the artwork reads correctly against an unlit gallery wall. */
-	.console {
-		--ink: #08080a;
-		--paper: #ece7dd;
-		--muted: rgba(236, 231, 221, 0.55);
-		--hair: rgba(236, 231, 221, 0.16);
-		--seal: #c1452c;
-		position: relative;
-		min-height: 100vh;
-		margin-top: -4.5rem;
-		padding: 4.5rem 0 6rem;
-		color: var(--paper);
-	}
-
-	.ground {
-		position: fixed;
-		inset: 0;
-		z-index: -1;
-		background:
-			radial-gradient(120% 80% at 50% -10%, #17161a 0%, var(--ink) 55%, #050506 100%);
-	}
-
-	.ground::after {
-		content: '';
-		position: absolute;
-		inset: 0;
-		opacity: 0.28;
-		mix-blend-mode: overlay;
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-	}
-
-	.wrap {
-		width: min(88rem, 100%);
-		margin: 0 auto;
-		padding: 0 clamp(1rem, 4vw, 3.5rem);
-	}
-
-	.masthead {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: flex-end;
-		justify-content: space-between;
-		gap: 1.5rem;
-		padding: clamp(2.5rem, 7vw, 5rem) 0 2rem;
-		border-bottom: 1px solid var(--hair);
-	}
-
-	.eyebrow {
-		margin: 0 0 0.75rem;
-		font-size: 0.7rem;
-		text-transform: uppercase;
-		letter-spacing: 0.42em;
-		color: var(--seal);
-	}
-
-	.title {
-		margin: 0;
-		font-size: clamp(3rem, 11vw, 7rem);
-		line-height: 0.85;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-	}
-
-	.identity {
-		display: flex;
-		align-items: center;
-		gap: 1.25rem;
-		font-size: 0.78rem;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
-	}
-
-	.email {
-		color: var(--muted);
-	}
-
-	.signout {
-		padding: 0.5rem 1.1rem;
-		border: 1px solid var(--hair);
-		color: var(--paper);
-		transition: border-color 200ms, color 200ms;
-	}
-
-	.signout:hover {
-		border-color: var(--seal);
-		color: var(--seal);
-	}
-
 	.actions {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
@@ -362,279 +200,5 @@ const postTypeLabels: Record<string, string> = {
 		margin: 2.5rem 0 4rem;
 		background: var(--hair);
 		border: 1px solid var(--hair);
-	}
-
-	.action {
-		display: flex;
-		align-items: center;
-		gap: 1.25rem;
-		padding: clamp(1.5rem, 3vw, 2.25rem);
-		background: rgba(8, 8, 10, 0.75);
-		transition: background 250ms;
-	}
-
-	.action:hover {
-		background: rgba(193, 69, 44, 0.09);
-	}
-
-	.seal {
-		flex: none;
-		display: grid;
-		place-items: center;
-		width: 3rem;
-		height: 3rem;
-		font-size: 1.5rem;
-		line-height: 1;
-		color: var(--paper);
-		background: var(--seal);
-		transition: transform 250ms cubic-bezier(0.2, 0.7, 0.2, 1);
-	}
-
-	.action:hover .seal {
-		transform: rotate(-6deg) scale(1.06);
-	}
-
-	.action-copy {
-		display: flex;
-		flex-direction: column;
-		gap: 0.35rem;
-	}
-
-	.action-title {
-		font-size: 1.4rem;
-		text-transform: uppercase;
-		letter-spacing: 0.16em;
-	}
-
-	.action-note {
-		font-size: 0.85rem;
-		color: var(--muted);
-	}
-
-	.action-arrow {
-		margin-left: auto;
-		font-size: 1.4rem;
-		color: var(--muted);
-		transition: transform 250ms, color 250ms;
-	}
-
-	.action:hover .action-arrow {
-		transform: translateX(0.35rem);
-		color: var(--seal);
-	}
-
-	.entity {
-		margin-bottom: 4rem;
-	}
-
-	.entity-head {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: baseline;
-		gap: 0.75rem 1.5rem;
-		padding-bottom: 1rem;
-		border-bottom: 1px solid var(--hair);
-	}
-
-	.entity-head h2 {
-		margin: 0;
-		font-size: 1.5rem;
-		text-transform: uppercase;
-		letter-spacing: 0.2em;
-	}
-
-	.index {
-		margin-right: 0.75rem;
-		font-size: 0.75rem;
-		letter-spacing: 0.2em;
-		color: var(--seal);
-		vertical-align: 0.35em;
-	}
-
-	.tally {
-		margin: 0;
-		font-size: 0.78rem;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: var(--muted);
-	}
-
-	.entity-links {
-		display: flex;
-		gap: 1.25rem;
-		margin-left: auto;
-	}
-
-	.ghost {
-		font-size: 0.78rem;
-		letter-spacing: 0.16em;
-		text-transform: uppercase;
-		color: var(--muted);
-		transition: color 200ms;
-	}
-
-	.ghost:hover {
-		color: var(--seal);
-	}
-
-	.grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
-		gap: clamp(1rem, 2.5vw, 2rem);
-		margin: 1.75rem 0 0;
-		padding: 0;
-		list-style: none;
-	}
-
-	.card {
-		display: block;
-	}
-
-	.frame {
-		position: relative;
-		display: block;
-		overflow: hidden;
-		background: #101013;
-		border: 1px solid var(--hair);
-	}
-
-	.portrait { aspect-ratio: 4 / 5; }
-	.landscape { aspect-ratio: 3 / 2; }
-	.stack { aspect-ratio: 3 / 2; }
-
-	.frame img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		filter: saturate(0.75) brightness(0.86);
-		transition: transform 600ms cubic-bezier(0.2, 0.7, 0.2, 1), filter 400ms;
-	}
-
-	.card:hover .frame img {
-		transform: scale(1.04);
-		filter: saturate(1) brightness(1);
-	}
-
-	.card:hover .frame {
-		border-color: rgba(236, 231, 221, 0.4);
-	}
-
-	/* Collections hold artwork rather than a single image, so their cover is a
-	   stack of member pieces fanned out like prints on a table. */
-	.stack .layer {
-		position: absolute;
-		inset: 0 0 0 auto;
-		width: 62%;
-		border-left: 1px solid rgba(8, 8, 10, 0.85);
-		transition: transform 600ms cubic-bezier(0.2, 0.7, 0.2, 1), filter 400ms;
-	}
-
-	.stack .layer-0 { left: 0; right: auto; width: 100%; z-index: 1; }
-	.stack .layer-1 { right: 0; width: 46%; z-index: 2; transform: translateX(18%); }
-	.stack .layer-2 { right: 0; width: 30%; z-index: 3; transform: translateX(36%); }
-
-	.card:hover .stack .layer-1 { transform: translateX(0); }
-	.card:hover .stack .layer-2 { transform: translateX(0); }
-
-	/* An empty frame is common for posts, which usually carry no cover. Hatching
-	   reads as a prepared surface rather than a hole in the page. */
-	.frame:has(> .no-image) {
-		background-image: repeating-linear-gradient(
-			-45deg,
-			rgba(236, 231, 221, 0.05) 0 1px,
-			transparent 1px 9px
-		);
-	}
-
-	.no-image {
-		position: absolute;
-		inset: 0;
-		display: grid;
-		place-items: center;
-		font-size: 0.75rem;
-		letter-spacing: 0.2em;
-		text-transform: uppercase;
-		color: rgba(236, 231, 221, 0.32);
-	}
-
-	.status {
-		position: absolute;
-		top: 0.75rem;
-		left: 0.75rem;
-		z-index: 4;
-		padding: 0.25rem 0.6rem;
-		font-size: 0.62rem;
-		letter-spacing: 0.18em;
-		text-transform: uppercase;
-		backdrop-filter: blur(6px);
-		background: rgba(8, 8, 10, 0.6);
-		border: 1px solid var(--hair);
-	}
-
-	.status.is-live { color: var(--paper); border-color: rgba(236, 231, 221, 0.45); }
-	.status.is-draft { color: var(--seal); border-color: rgba(193, 69, 44, 0.6); }
-	.status.is-sold { color: rgba(236, 231, 221, 0.5); }
-
-	.card-body {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: 1rem;
-		padding-top: 0.85rem;
-	}
-
-	.card-title {
-		font-size: 1.05rem;
-		letter-spacing: 0.04em;
-	}
-
-	.card-meta {
-		font-size: 0.75rem;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
-		color: var(--muted);
-		white-space: nowrap;
-	}
-
-	.price { color: var(--seal); }
-
-	.empty {
-		display: block;
-		margin-top: 1.75rem;
-		padding: 2.5rem;
-		border: 1px dashed var(--hair);
-		font-size: 0.9rem;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: var(--muted);
-		text-align: center;
-		transition: border-color 200ms, color 200ms;
-	}
-
-	.empty:hover {
-		border-color: var(--seal);
-		color: var(--paper);
-	}
-
-	.empty.is-static:hover {
-		border-color: var(--hair);
-		color: var(--muted);
-	}
-
-	.reveal {
-		animation: rise 700ms cubic-bezier(0.2, 0.7, 0.2, 1) backwards;
-	}
-
-	@keyframes rise {
-		from { opacity: 0; transform: translateY(1.25rem); }
-		to { opacity: 1; transform: none; }
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.reveal { animation: none; }
-		.frame img,
-		.stack .layer,
-		.seal,
-		.action-arrow { transition: none; }
 	}
 </style>

--- a/code/src/pages/admin.astro
+++ b/code/src/pages/admin.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import ActionBar from '../components/admin/ActionBar.astro';
 import CardGrid from '../components/admin/CardGrid.astro';
 import ConsoleSection from '../components/admin/ConsoleSection.astro';
 import ConsoleShell from '../components/admin/ConsoleShell.astro';
@@ -59,27 +60,24 @@ const draftTally = (tally: { total: number; published: number }) =>
 	`${tally.total} total · ${tally.published} published · ${tally.total - tally.published} draft`;
 ---
 <ConsoleShell title="Admin — EONMUN" heading="Admin" email={session.user.email}>
-	<div class="actions">
+	<ActionBar>
 		<CreateAction
 			href="/admin/artworks/new"
 			title="New artwork"
 			note="Images, dimensions, collections, private price."
-			delay={60}
 		/>
 		<CreateAction
 			href="/admin/collections/new"
 			title="New collection"
 			note="Group artwork and choose the cover piece."
-			delay={120}
 		/>
-	</div>
+	</ActionBar>
 
 	<ConsoleSection
 		index="01"
 		title="Artwork"
 		tally={draftTally(artworks.tally)}
-		links={[{ href: '/admin/artworks/new', label: 'New' }, { href: '/admin/artworks', label: 'All artwork →' }]}
-		delay={180}
+		links={[{ href: '/admin/artworks/new', label: 'New artwork' }, { href: '/admin/artworks', label: 'All artwork →' }]}
 	>
 		{artworks.recent.length === 0 ? (
 			<EmptyState href="/admin/artworks/new" label="No artwork yet. Add the first piece →" />
@@ -107,8 +105,7 @@ const draftTally = (tally: { total: number; published: number }) =>
 		index="02"
 		title="Collections"
 		tally={draftTally(collections.tally)}
-		links={[{ href: '/admin/collections/new', label: 'New' }, { href: '/admin/collections', label: 'All collections →' }]}
-		delay={240}
+		links={[{ href: '/admin/collections/new', label: 'New collection' }, { href: '/admin/collections', label: 'All collections →' }]}
 	>
 		{collections.recent.length === 0 ? (
 			<EmptyState href="/admin/collections/new" label="No collections yet. Group your first pieces →" />
@@ -137,7 +134,6 @@ const draftTally = (tally: { total: number; published: number }) =>
 		title="Private sales"
 		tally={`${store.tally.total} listed · ${store.tally.available} available · ${store.tally.sold} sold`}
 		links={[{ href: '/admin/artworks/new', label: 'New artwork' }, { href: '/admin/artworks', label: 'All artwork →' }]}
-		delay={300}
 	>
 		{store.recent.length === 0 ? (
 			<EmptyState href="/admin/artworks/new" label="Nothing listed. Give an artwork a price →" />
@@ -168,7 +164,6 @@ const draftTally = (tally: { total: number; published: number }) =>
 		title="Posts"
 		tally={`${postEntries.length} written · edited in the repository`}
 		links={[{ href: '/posts', label: 'All posts →' }]}
-		delay={360}
 	>
 		{posts.length === 0 ? (
 			<EmptyState label="No posts yet." />
@@ -192,13 +187,3 @@ const draftTally = (tally: { total: number; published: number }) =>
 	</ConsoleSection>
 </ConsoleShell>
 
-<style>
-	.actions {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
-		gap: 1px;
-		margin: 2.5rem 0 4rem;
-		background: var(--hair);
-		border: 1px solid var(--hair);
-	}
-</style>

--- a/code/src/pages/admin/artworks/index.astro
+++ b/code/src/pages/admin/artworks/index.astro
@@ -1,15 +1,72 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
-import { getAdminArtworks } from '../../../db/admin';
+import CardGrid from '../../../components/admin/CardGrid.astro';
+import ConsoleSection from '../../../components/admin/ConsoleSection.astro';
+import ConsoleShell from '../../../components/admin/ConsoleShell.astro';
+import CreateAction from '../../../components/admin/CreateAction.astro';
+import EmptyState from '../../../components/admin/EmptyState.astro';
+import MediaCard from '../../../components/admin/MediaCard.astro';
+import { getAdminArtworkCards } from '../../../db/admin';
 import { requireAdminPage } from '../../../lib/admin-guard';
 import { getRuntimeEnv } from '../../../lib/runtime-env';
+
 export const prerender = false;
+
 const env = getRuntimeEnv();
 const access = await requireAdminPage(Astro.request, env, '/admin/artworks');
 if ('response' in access) return access.response;
-const artworks = await getAdminArtworks(env);
+const { session } = access;
+
+const artworks = await getAdminArtworkCards(env);
+const published = artworks.filter((artwork) => artwork.publishedAt !== null).length;
+const tally = `${artworks.length} total · ${published} published · ${artworks.length - published} draft`;
 ---
-<BaseLayout title="Artwork administration — EONMUN"><main class="container mx-auto px-4 py-8">
-	<div class="flex justify-between items-center mb-8"><h1 class="text-4xl font-bold">Artwork</h1><a class="underline" href="/admin/artworks/new">New artwork</a></div>
-	<div class="space-y-3">{artworks.map((artwork) => <a class="flex justify-between border rounded p-4" href={`/admin/artworks/${artwork.slug}`}><span>{artwork.title}</span><span>{artwork.publishedAt ? 'Published' : 'Draft'}</span></a>)}</div>
-</main></BaseLayout>
+<ConsoleShell
+	title="Artwork — EONMUN admin"
+	heading="Artwork"
+	email={session.user.email}
+	backHref="/admin"
+	backLabel="Console"
+>
+	<div class="actions">
+		<CreateAction
+			href="/admin/artworks/new"
+			title="New artwork"
+			note="Images, dimensions, collections, private price."
+			delay={60}
+		/>
+	</div>
+
+	<ConsoleSection title="Every piece" tally={tally} links={[{ href: '/admin/collections', label: 'Collections →' }]} delay={120}>
+		{artworks.length === 0 ? (
+			<EmptyState href="/admin/artworks/new" label="No artwork yet. Add the first piece →" />
+		) : (
+			<CardGrid>
+				{artworks.map((artwork) => (
+					<li>
+						<MediaCard
+							href={`/admin/artworks/${artwork.slug}`}
+							title={artwork.title}
+							meta={artwork.year ? String(artwork.year) : 'Year unset'}
+							imageUrl={artwork.imageUrl}
+							status={{
+								label: artwork.publishedAt ? 'Published' : 'Draft',
+								tone: artwork.publishedAt ? 'live' : 'draft',
+							}}
+						/>
+					</li>
+				))}
+			</CardGrid>
+		)}
+	</ConsoleSection>
+</ConsoleShell>
+
+<style>
+	.actions {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
+		gap: 1px;
+		margin: 2.5rem 0 4rem;
+		background: var(--hair);
+		border: 1px solid var(--hair);
+	}
+</style>

--- a/code/src/pages/admin/artworks/index.astro
+++ b/code/src/pages/admin/artworks/index.astro
@@ -1,4 +1,5 @@
 ---
+import ActionBar from '../../../components/admin/ActionBar.astro';
 import CardGrid from '../../../components/admin/CardGrid.astro';
 import ConsoleSection from '../../../components/admin/ConsoleSection.astro';
 import ConsoleShell from '../../../components/admin/ConsoleShell.astro';
@@ -27,16 +28,15 @@ const tally = `${artworks.length} total · ${published} published · ${artworks.
 	backHref="/admin"
 	backLabel="Console"
 >
-	<div class="actions">
+	<ActionBar>
 		<CreateAction
 			href="/admin/artworks/new"
 			title="New artwork"
 			note="Images, dimensions, collections, private price."
-			delay={60}
 		/>
-	</div>
+	</ActionBar>
 
-	<ConsoleSection title="Every piece" tally={tally} links={[{ href: '/admin/collections', label: 'Collections →' }]} delay={120}>
+	<ConsoleSection title="Every piece" tally={tally} links={[{ href: '/admin/collections', label: 'Collections →' }]}>
 		{artworks.length === 0 ? (
 			<EmptyState href="/admin/artworks/new" label="No artwork yet. Add the first piece →" />
 		) : (
@@ -60,13 +60,3 @@ const tally = `${artworks.length} total · ${published} published · ${artworks.
 	</ConsoleSection>
 </ConsoleShell>
 
-<style>
-	.actions {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
-		gap: 1px;
-		margin: 2.5rem 0 4rem;
-		background: var(--hair);
-		border: 1px solid var(--hair);
-	}
-</style>

--- a/code/src/pages/admin/collections/index.astro
+++ b/code/src/pages/admin/collections/index.astro
@@ -1,15 +1,72 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
-import { getAdminCollections } from '../../../db/admin';
+import CardGrid from '../../../components/admin/CardGrid.astro';
+import ConsoleSection from '../../../components/admin/ConsoleSection.astro';
+import ConsoleShell from '../../../components/admin/ConsoleShell.astro';
+import CoverStack from '../../../components/admin/CoverStack.astro';
+import CreateAction from '../../../components/admin/CreateAction.astro';
+import EmptyState from '../../../components/admin/EmptyState.astro';
+import { getAdminCollectionCards } from '../../../db/admin';
 import { requireAdminPage } from '../../../lib/admin-guard';
 import { getRuntimeEnv } from '../../../lib/runtime-env';
+
 export const prerender = false;
+
 const env = getRuntimeEnv();
 const access = await requireAdminPage(Astro.request, env, '/admin/collections');
 if ('response' in access) return access.response;
-const collections = await getAdminCollections(env);
+const { session } = access;
+
+const collections = await getAdminCollectionCards(env);
+const published = collections.filter((collection) => collection.publishedAt !== null).length;
+const tally = `${collections.length} total · ${published} published · ${collections.length - published} draft`;
 ---
-<BaseLayout title="Collection administration — EONMUN"><main class="container mx-auto px-4 py-8">
-	<div class="flex justify-between items-center mb-8"><h1 class="text-4xl font-bold">Collections</h1><a class="underline" href="/admin/collections/new">New collection</a></div>
-	<div class="space-y-3">{collections.map((collection) => <a class="flex justify-between border rounded p-4" href={`/admin/collections/${collection.slug}`}><span>{collection.name}</span><span>{collection.publishedAt ? 'Published' : 'Draft'}</span></a>)}</div>
-</main></BaseLayout>
+<ConsoleShell
+	title="Collections — EONMUN admin"
+	heading="Collections"
+	email={session.user.email}
+	backHref="/admin"
+	backLabel="Console"
+>
+	<div class="actions">
+		<CreateAction
+			href="/admin/collections/new"
+			title="New collection"
+			note="Group artwork and choose the cover piece."
+			delay={60}
+		/>
+	</div>
+
+	<ConsoleSection title="Every collection" tally={tally} links={[{ href: '/admin/artworks', label: 'Artwork →' }]} delay={120}>
+		{collections.length === 0 ? (
+			<EmptyState href="/admin/collections/new" label="No collections yet. Group your first pieces →" />
+		) : (
+			<CardGrid>
+				{collections.map((collection) => (
+					<li>
+						<CoverStack
+							href={`/admin/collections/${collection.slug}`}
+							name={collection.name}
+							artworkCount={collection.artworkCount}
+							coverUrls={collection.coverUrls}
+							status={{
+								label: collection.publishedAt ? 'Published' : 'Draft',
+								tone: collection.publishedAt ? 'live' : 'draft',
+							}}
+						/>
+					</li>
+				))}
+			</CardGrid>
+		)}
+	</ConsoleSection>
+</ConsoleShell>
+
+<style>
+	.actions {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
+		gap: 1px;
+		margin: 2.5rem 0 4rem;
+		background: var(--hair);
+		border: 1px solid var(--hair);
+	}
+</style>

--- a/code/src/pages/admin/collections/index.astro
+++ b/code/src/pages/admin/collections/index.astro
@@ -1,4 +1,5 @@
 ---
+import ActionBar from '../../../components/admin/ActionBar.astro';
 import CardGrid from '../../../components/admin/CardGrid.astro';
 import ConsoleSection from '../../../components/admin/ConsoleSection.astro';
 import ConsoleShell from '../../../components/admin/ConsoleShell.astro';
@@ -27,16 +28,15 @@ const tally = `${collections.length} total · ${published} published · ${collec
 	backHref="/admin"
 	backLabel="Console"
 >
-	<div class="actions">
+	<ActionBar>
 		<CreateAction
 			href="/admin/collections/new"
 			title="New collection"
 			note="Group artwork and choose the cover piece."
-			delay={60}
 		/>
-	</div>
+	</ActionBar>
 
-	<ConsoleSection title="Every collection" tally={tally} links={[{ href: '/admin/artworks', label: 'Artwork →' }]} delay={120}>
+	<ConsoleSection title="Every collection" tally={tally} links={[{ href: '/admin/artworks', label: 'Artwork →' }]}>
 		{collections.length === 0 ? (
 			<EmptyState href="/admin/collections/new" label="No collections yet. Group your first pieces →" />
 		) : (
@@ -60,13 +60,3 @@ const tally = `${collections.length} total · ${published} published · ${collec
 	</ConsoleSection>
 </ConsoleShell>
 
-<style>
-	.actions {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
-		gap: 1px;
-		margin: 2.5rem 0 4rem;
-		background: var(--hair);
-		border: 1px solid var(--hair);
-	}
-</style>

--- a/code/test/admin-dashboard.test.ts
+++ b/code/test/admin-dashboard.test.ts
@@ -3,6 +3,7 @@ import { createClient, type Client } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import { unlink } from "node:fs/promises";
 import * as schema from "../src/db/schema";
+import { createCatalogSchema } from "./schema-fixture";
 import { getAdminArtworkCards, getAdminCollectionCards, getAdminDashboard } from "../src/db/admin";
 
 const env = { TURSO_DATABASE_URL: "https://unused.test" };
@@ -33,15 +34,7 @@ beforeEach(async () => {
 	databasePath = `/tmp/eonmun-dashboard-test-${crypto.randomUUID()}.db`;
 	client = createClient({ url: `file:${databasePath}` });
 	db = drizzle(client, { schema });
-	await client.executeMultiple(`
-		CREATE TABLE collections (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, published_at INTEGER, locale TEXT NOT NULL DEFAULT 'en', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
-		CREATE TABLE artworks (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, artist TEXT, year INTEGER, width REAL, height REAL, depth REAL, dimension_unit TEXT DEFAULT 'in', published_at INTEGER, locale TEXT NOT NULL DEFAULT 'en', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
-		CREATE TABLE artwork_images (id INTEGER PRIMARY KEY AUTOINCREMENT, artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, url TEXT NOT NULL, caption TEXT, is_default INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
-		CREATE UNIQUE INDEX artwork_images_one_default_per_artwork ON artwork_images(artwork_id) WHERE is_default = 1;
-		CREATE TABLE artworks_to_collections (artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, collection_id INTEGER NOT NULL REFERENCES collections(id) ON DELETE CASCADE, is_default_for_collection INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL, PRIMARY KEY(artwork_id, collection_id));
-		CREATE UNIQUE INDEX artwork_collection_one_default_per_collection ON artworks_to_collections(collection_id) WHERE is_default_for_collection = 1;
-		CREATE TABLE products (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, artwork_id INTEGER REFERENCES artworks(id) ON DELETE SET NULL, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, image_url TEXT, price INTEGER NOT NULL, quantity INTEGER, listed_at INTEGER NOT NULL, sold_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
-	`);
+	await createCatalogSchema(client);
 });
 
 afterEach(async () => {
@@ -74,6 +67,24 @@ describe("admin dashboard", () => {
 		expect(card.imageUrl).toBe("https://r2.eonmun.com/cover.jpeg");
 	});
 
+	// The partial unique index caps defaults at one but never requires one, so
+	// this state is representable by direct SQL. admin-input.ts:67 promotes the
+	// first image on every application write, which is what keeps it unreachable
+	// in production — if that promotion is ever removed, these covers go blank.
+	test("shows no cover for an artwork whose images carry no default flag", async () => {
+		const id = await insertArtwork("Unflagged", "unflagged", true);
+		await insertImage(id, "https://r2.eonmun.com/first.jpeg", false);
+		await insertImage(id, "https://r2.eonmun.com/second.jpeg", false);
+
+		const [card] = await getAdminArtworkCards(env, db);
+		expect(card.imageUrl).toBeNull();
+	});
+
+	test("returns empty lists to the list pages for a new catalog", async () => {
+		expect(await getAdminArtworkCards(env, db)).toEqual([]);
+		expect(await getAdminCollectionCards(env, db)).toEqual([]);
+	});
+
 	test("counts every member and leads the cover fan with the collection's cover piece", async () => {
 		const plain = await insertArtwork("Plain", "plain", true);
 		const cover = await insertArtwork("Cover", "cover", true);
@@ -91,7 +102,16 @@ describe("admin dashboard", () => {
 			});
 		}
 
-		const [collection] = await getAdminCollectionCards(env, db);
+		await client.execute({
+			sql: "INSERT INTO collections (name, slug, published_at, created_at, updated_at) VALUES ('Alpha', 'alpha', ?, ?, ?)",
+			args: [STAMP, STAMP, STAMP],
+		});
+
+		const cards = await getAdminCollectionCards(env, db);
+		// The collections page lists alphabetically.
+		expect(cards.map((card) => card.slug)).toEqual(["alpha", "botanica"]);
+
+		const collection = cards.find((card) => card.slug === "botanica")!;
 		// Three members, but only two carry an image, and the cover piece leads.
 		expect(collection.artworkCount).toBe(3);
 		expect(collection.coverUrls).toEqual([

--- a/code/test/admin-dashboard.test.ts
+++ b/code/test/admin-dashboard.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createClient, type Client } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { unlink } from "node:fs/promises";
+import * as schema from "../src/db/schema";
+import { getAdminArtworkCards, getAdminCollectionCards, getAdminDashboard } from "../src/db/admin";
+
+const env = { TURSO_DATABASE_URL: "https://unused.test" };
+let client: Client;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+let databasePath: string;
+
+// created_at holds whole seconds, so fixtures share one stamp on purpose: it is
+// the tie the id ordering has to break.
+const STAMP = 1_700_000_000;
+
+async function insertArtwork(title: string, slug: string, published: boolean) {
+	const result = await client.execute({
+		sql: "INSERT INTO artworks (title, slug, year, published_at, created_at, updated_at) VALUES (?, ?, 2026, ?, ?, ?) RETURNING id",
+		args: [title, slug, published ? STAMP : null, STAMP, STAMP],
+	});
+	return Number(result.rows[0].id);
+}
+
+async function insertImage(artworkId: number, url: string, isDefault: boolean) {
+	await client.execute({
+		sql: "INSERT INTO artwork_images (artwork_id, url, is_default, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+		args: [artworkId, url, isDefault ? 1 : 0, STAMP, STAMP],
+	});
+}
+
+beforeEach(async () => {
+	databasePath = `/tmp/eonmun-dashboard-test-${crypto.randomUUID()}.db`;
+	client = createClient({ url: `file:${databasePath}` });
+	db = drizzle(client, { schema });
+	await client.executeMultiple(`
+		CREATE TABLE collections (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, published_at INTEGER, locale TEXT NOT NULL DEFAULT 'en', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+		CREATE TABLE artworks (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, artist TEXT, year INTEGER, width REAL, height REAL, depth REAL, dimension_unit TEXT DEFAULT 'in', published_at INTEGER, locale TEXT NOT NULL DEFAULT 'en', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+		CREATE TABLE artwork_images (id INTEGER PRIMARY KEY AUTOINCREMENT, artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, url TEXT NOT NULL, caption TEXT, is_default INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+		CREATE UNIQUE INDEX artwork_images_one_default_per_artwork ON artwork_images(artwork_id) WHERE is_default = 1;
+		CREATE TABLE artworks_to_collections (artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, collection_id INTEGER NOT NULL REFERENCES collections(id) ON DELETE CASCADE, is_default_for_collection INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL, PRIMARY KEY(artwork_id, collection_id));
+		CREATE UNIQUE INDEX artwork_collection_one_default_per_collection ON artworks_to_collections(collection_id) WHERE is_default_for_collection = 1;
+		CREATE TABLE products (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, artwork_id INTEGER REFERENCES artworks(id) ON DELETE SET NULL, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, image_url TEXT, price INTEGER NOT NULL, quantity INTEGER, listed_at INTEGER NOT NULL, sold_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+	`);
+});
+
+afterEach(async () => {
+	client.close();
+	await unlink(databasePath).catch(() => undefined);
+});
+
+describe("admin dashboard", () => {
+	test("reports zeroed tallies and empty lists for a new catalog", async () => {
+		const dashboard = await getAdminDashboard(env, db);
+		expect(dashboard.artworks).toEqual({ recent: [], tally: { total: 0, published: 0 } });
+		expect(dashboard.collections).toEqual({ recent: [], tally: { total: 0, published: 0 } });
+		expect(dashboard.store).toEqual({ recent: [], tally: { total: 0, available: 0, sold: 0 } });
+	});
+
+	test("keeps the newest three in insertion order when created_at ties", async () => {
+		for (const [index, slug] of ["one", "two", "three", "four"].entries()) {
+			await insertArtwork(`Work ${index + 1}`, slug, index < 2);
+		}
+		const dashboard = await getAdminDashboard(env, db);
+		expect(dashboard.artworks.recent.map((artwork) => artwork.slug)).toEqual(["four", "three", "two"]);
+		expect(dashboard.artworks.tally).toEqual({ total: 4, published: 2 });
+	});
+
+	test("shows the flagged default image rather than the first one stored", async () => {
+		const id = await insertArtwork("Camélia", "camelia", true);
+		await insertImage(id, "https://r2.eonmun.com/second.jpeg", false);
+		await insertImage(id, "https://r2.eonmun.com/cover.jpeg", true);
+		const [card] = await getAdminDashboard(env, db).then((dashboard) => dashboard.artworks.recent);
+		expect(card.imageUrl).toBe("https://r2.eonmun.com/cover.jpeg");
+	});
+
+	test("counts every member and leads the cover fan with the collection's cover piece", async () => {
+		const plain = await insertArtwork("Plain", "plain", true);
+		const cover = await insertArtwork("Cover", "cover", true);
+		const bare = await insertArtwork("Bare", "bare", true);
+		await insertImage(plain, "https://r2.eonmun.com/plain.jpeg", true);
+		await insertImage(cover, "https://r2.eonmun.com/cover.jpeg", true);
+		await client.execute({
+			sql: "INSERT INTO collections (name, slug, published_at, created_at, updated_at) VALUES ('Botánica', 'botanica', ?, ?, ?)",
+			args: [STAMP, STAMP, STAMP],
+		});
+		for (const [artworkId, isCover] of [[plain, 0], [cover, 1], [bare, 0]] as const) {
+			await client.execute({
+				sql: "INSERT INTO artworks_to_collections (artwork_id, collection_id, is_default_for_collection, created_at) VALUES (?, 1, ?, ?)",
+				args: [artworkId, isCover, STAMP],
+			});
+		}
+
+		const [collection] = await getAdminCollectionCards(env, db);
+		// Three members, but only two carry an image, and the cover piece leads.
+		expect(collection.artworkCount).toBe(3);
+		expect(collection.coverUrls).toEqual([
+			"https://r2.eonmun.com/cover.jpeg",
+			"https://r2.eonmun.com/plain.jpeg",
+		]);
+	});
+
+	test("resolves a product back to the artwork that edits it", async () => {
+		const artworkId = await insertArtwork("Sold Work", "sold-work", true);
+		await client.execute({
+			sql: "INSERT INTO products (type, artwork_id, name, slug, price, quantity, listed_at, created_at, updated_at) VALUES ('artwork', ?, 'Sold Work', 'sold-work', 45678, 1, ?, ?, ?)",
+			args: [artworkId, STAMP, STAMP, STAMP],
+		});
+		await client.execute({
+			sql: "INSERT INTO products (type, name, slug, price, quantity, listed_at, sold_at, created_at, updated_at) VALUES ('print', 'Detached', 'detached', 1000, 0, ?, ?, ?, ?)",
+			args: [STAMP, STAMP, STAMP, STAMP],
+		});
+
+		const { store } = await getAdminDashboard(env, db);
+		expect(store.tally).toEqual({ total: 2, available: 1, sold: 1 });
+		const bySlug = new Map(store.recent.map((product) => [product.slug, product]));
+		expect(bySlug.get("sold-work")?.artworkSlug).toBe("sold-work");
+		expect(bySlug.get("detached")?.artworkSlug).toBeNull();
+	});
+
+	test("lists every artwork with its cover for the artwork admin page", async () => {
+		const zebra = await insertArtwork("Zebra", "zebra", false);
+		await insertArtwork("Alpha", "alpha", true);
+		await insertImage(zebra, "https://r2.eonmun.com/zebra.jpeg", true);
+
+		const cards = await getAdminArtworkCards(env, db);
+		expect(cards.map((card) => card.slug)).toEqual(["alpha", "zebra"]);
+		expect(cards[0].imageUrl).toBeNull();
+		expect(cards[1].imageUrl).toBe("https://r2.eonmun.com/zebra.jpeg");
+		expect(cards[1].publishedAt).toBeNull();
+	});
+});

--- a/code/test/admin-mutations.test.ts
+++ b/code/test/admin-mutations.test.ts
@@ -4,6 +4,7 @@ import { drizzle } from "drizzle-orm/libsql";
 import { eq } from "drizzle-orm";
 import { unlink } from "node:fs/promises";
 import * as schema from "../src/db/schema";
+import { createCatalogSchema } from "./schema-fixture";
 import {
 	createArtworkAdmin,
 	createCollectionAdmin,
@@ -43,16 +44,7 @@ beforeEach(async () => {
 	databasePath = `/tmp/eonmun-admin-test-${crypto.randomUUID()}.db`;
 	client = createClient({ url: `file:${databasePath}` });
 	db = drizzle(client, { schema });
-	await client.executeMultiple(`
-		CREATE TABLE collections (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, published_at INTEGER, locale TEXT NOT NULL DEFAULT 'en', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
-		CREATE TABLE artworks (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, artist TEXT, year INTEGER, width REAL, height REAL, depth REAL, dimension_unit TEXT DEFAULT 'in', published_at INTEGER, locale TEXT NOT NULL DEFAULT 'en', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
-		CREATE TABLE artwork_images (id INTEGER PRIMARY KEY AUTOINCREMENT, artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, url TEXT NOT NULL, caption TEXT, is_default INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
-		CREATE UNIQUE INDEX artwork_images_one_default_per_artwork ON artwork_images(artwork_id) WHERE is_default = 1;
-		CREATE TABLE artworks_to_collections (artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, collection_id INTEGER NOT NULL REFERENCES collections(id) ON DELETE CASCADE, is_default_for_collection INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL, PRIMARY KEY(artwork_id, collection_id));
-		CREATE UNIQUE INDEX artwork_collection_one_default_per_collection ON artworks_to_collections(collection_id) WHERE is_default_for_collection = 1;
-		CREATE TABLE products (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, artwork_id INTEGER REFERENCES artworks(id) ON DELETE SET NULL, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, image_url TEXT, price INTEGER NOT NULL, quantity INTEGER, listed_at INTEGER NOT NULL, sold_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
-		CREATE TABLE homepage_artworks (id INTEGER PRIMARY KEY AUTOINCREMENT, artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, position INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
-	`);
+	await createCatalogSchema(client);
 });
 
 afterEach(async () => {

--- a/code/test/schema-fixture.ts
+++ b/code/test/schema-fixture.ts
@@ -1,0 +1,17 @@
+import type { Client } from "@libsql/client";
+
+// One hand-written copy of the catalog schema for the whole suite. Two copies
+// drift: a column added to one leaves the other testing a schema the queries no
+// longer run against, and the suite still passes.
+export async function createCatalogSchema(client: Client) {
+	await client.executeMultiple(`
+		CREATE TABLE collections (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, published_at INTEGER, locale TEXT NOT NULL DEFAULT 'en', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+		CREATE TABLE artworks (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, artist TEXT, year INTEGER, width REAL, height REAL, depth REAL, dimension_unit TEXT DEFAULT 'in', published_at INTEGER, locale TEXT NOT NULL DEFAULT 'en', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+		CREATE TABLE artwork_images (id INTEGER PRIMARY KEY AUTOINCREMENT, artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, url TEXT NOT NULL, caption TEXT, is_default INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+		CREATE UNIQUE INDEX artwork_images_one_default_per_artwork ON artwork_images(artwork_id) WHERE is_default = 1;
+		CREATE TABLE artworks_to_collections (artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, collection_id INTEGER NOT NULL REFERENCES collections(id) ON DELETE CASCADE, is_default_for_collection INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL, PRIMARY KEY(artwork_id, collection_id));
+		CREATE UNIQUE INDEX artwork_collection_one_default_per_collection ON artworks_to_collections(collection_id) WHERE is_default_for_collection = 1;
+		CREATE TABLE products (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, artwork_id INTEGER REFERENCES artworks(id) ON DELETE SET NULL, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, description TEXT, image_url TEXT, price INTEGER NOT NULL, quantity INTEGER, listed_at INTEGER NOT NULL, sold_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+		CREATE TABLE homepage_artworks (id INTEGER PRIMARY KEY AUTOINCREMENT, artwork_id INTEGER NOT NULL REFERENCES artworks(id) ON DELETE CASCADE, position INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+	`);
+}


### PR DESCRIPTION
## What

`/admin/artworks` and `/admin/collections` were unstyled text rows with no images, while the dashboard carried the whole console design. This extracts that design into components both surfaces use, then rebuilds the list pages on them.

**Artwork page** now shows every piece as a framed cover with a Published/Draft pill and its year, a "New artwork" seal action, a tally line, and a back link to the console. **Collections** gets the same treatment, with each collection's cover fanned from its member artwork.

## Components

New, under `code/src/components/admin/`:

| Component | Owns |
| --- | --- |
| `ConsoleShell` | the dark ground, the palette every console component inherits, the masthead and sign-out |
| `ConsoleSection` | a numbered band with its tally and links |
| `MediaCard` | framed image, status pill, title and meta — renders a `div` when there is nowhere to link |
| `CoverStack` | a collection's fan of member covers |
| `CardGrid` / `CreateAction` / `EmptyState` | the grid rhythm, the seal action, the empty prompts |

`admin.astro` now renders through these instead of its own copy of the markup, which is where most of the deleted lines come from.

## Covers come from SQL now

`lib/admin-input.ts` rejects a second default image and promotes the first when none is flagged, and the schema carries a partial unique index enforcing it — so joining on `isDefault` returns exactly one row per artwork. The old fan-out-then-fold-in-JS path is gone, along with its nested `Map<number, Map<number, …>>`. `getAdminArtworkCards` and `getAdminCollectionCards` hand the list pages the same shapes the dashboard uses.

`COLLECTION_COVER_LAYERS` now names the cover cap that `CoverStack`'s three styled layers depend on, so raising `DASHBOARD_LIMIT` no longer silently overflows the fan.

## Tests

Adds the `getAdminDashboard` coverage the last review asked for: zeroed tallies on an empty catalog, id-broken ordering when `created_at` ties, default-image selection over first-stored, member counting with cover-first fanning, and product-to-artwork slug resolution — plus `getAdminArtworkCards` ordering and cover resolution.

`bun test`: 60 pass, 0 fail. `bun run build` passes. All three admin pages were rendered against a seeded database and screenshotted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWkvt4PUhp5xVW7AE7U18B