### PR TITLE
feat(admin): theme the editor pages and forms on the console

### DIFF
--- a/code/src/components/admin/ArtworkForm.astro
+++ b/code/src/components/admin/ArtworkForm.astro
@@ -1,4 +1,7 @@
 ---
+import ErrorBanner from './ErrorBanner.astro';
+import FormFieldset from './FormFieldset.astro';
+import SubmitButton from './SubmitButton.astro';
 import type { SelectArtwork, SelectArtworkImage, SelectCollection, SelectProduct } from '../../db';
 
 interface Props {
@@ -6,47 +9,64 @@ interface Props {
 	artwork?: SelectArtwork & { images: SelectArtworkImage[]; collectionIds: number[]; product: SelectProduct | null };
 	collections: SelectCollection[];
 }
+
 const { action, artwork, collections } = Astro.props;
 const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, caption, isDefault })) ?? [];
 ---
-<form data-admin-artwork-form data-action={action} data-images={JSON.stringify(images)} class="space-y-6 max-w-3xl">
-	<div data-error hidden class="border border-red-500 p-3 rounded text-red-700"></div>
-	<div class="grid sm:grid-cols-2 gap-4">
-		<label class="space-y-1">Title <input class="admin-input" name="title" required value={artwork?.title ?? ''} /></label>
-		<label class="space-y-1">Slug <input class="admin-input" name="slug" required pattern="[a-z0-9]+(?:-[a-z0-9]+)*" value={artwork?.slug ?? ''} /></label>
-		<label class="space-y-1">Artist <input class="admin-input" name="artist" value={artwork?.artist ?? 'EONMUN'} /></label>
-		<label class="space-y-1">Year <input class="admin-input" name="year" type="number" min="1000" max="9999" value={artwork?.year ?? ''} /></label>
-	</div>
-	<label class="block space-y-1">Description <textarea class="admin-input min-h-32" name="description">{artwork?.description ?? ''}</textarea></label>
-	<fieldset class="border rounded p-4">
-		<legend class="px-2">Dimensions</legend>
-		<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
-			<label>Width <input class="admin-input" name="width" type="number" min="0" step="any" value={artwork?.width ?? ''} /></label>
-			<label>Height <input class="admin-input" name="height" type="number" min="0" step="any" value={artwork?.height ?? ''} /></label>
-			<label>Depth <input class="admin-input" name="depth" type="number" min="0" step="any" value={artwork?.depth ?? ''} /></label>
-			<label>Unit <select class="admin-input" name="dimensionUnit"><option selected={(artwork?.dimensionUnit ?? 'in') === 'in'}>in</option><option selected={artwork?.dimensionUnit === 'cm'}>cm</option></select></label>
-		</div>
-	</fieldset>
-	<fieldset class="border rounded p-4 space-y-3">
-		<legend class="px-2">Images</legend>
-		<input name="imageFiles" type="file" accept="image/jpeg,image/png,image/webp,image/gif,image/avif" multiple />
-		<p class="text-sm text-gray-500">JPEG, PNG, WebP, GIF, or AVIF. Maximum 10 MB each.</p>
-		<div data-image-list class="space-y-3"></div>
-	</fieldset>
-	<fieldset class="border rounded p-4 grid sm:grid-cols-2 gap-2">
-		<legend class="px-2">Collections</legend>
-		{collections.map((collection) => (
-			<label><input type="checkbox" name="collectionIds" value={collection.id} checked={artwork?.collectionIds.includes(collection.id)} /> {collection.name}</label>
-		))}
-	</fieldset>
-	<fieldset class="border rounded p-4 space-y-3">
-		<legend class="px-2">Private sale settings</legend>
-		<label class="block"><input type="checkbox" name="available" checked={(artwork?.product?.quantity ?? 0) > 0 && artwork?.product?.soldAt === null} /> Available for purchase</label>
-		<label class="block space-y-1">Private price (cents) <input class="admin-input" name="priceCents" type="number" min="1" step="1" value={artwork?.product?.price ?? ''} /></label>
-		<p class="text-sm text-gray-500">Prices are visible only in administration and Stripe Checkout.</p>
-	</fieldset>
-	{artwork ? <label class="block"><input type="checkbox" name="published" checked={artwork.publishedAt !== null} /> Published</label> : <p class="text-sm">New artwork is saved as a draft.</p>}
-	<button class="px-5 py-3 bg-gray-900 text-white dark:bg-white dark:text-gray-900 rounded" type="submit">Save artwork</button>
+<form data-admin-artwork-form data-action={action} data-images={JSON.stringify(images)}>
+	<ErrorBanner />
+
+	<FormFieldset legend="Piece" layout="columns">
+		<label>Title <input class="admin-input" name="title" required value={artwork?.title ?? ''} /></label>
+		<label>Slug <input class="admin-input" name="slug" required pattern="[a-z0-9]+(?:-[a-z0-9]+)*" value={artwork?.slug ?? ''} /></label>
+		<label>Artist <input class="admin-input" name="artist" value={artwork?.artist ?? 'EONMUN'} /></label>
+		<label>Year <input class="admin-input" name="year" type="number" min="1000" max="9999" value={artwork?.year ?? ''} /></label>
+		<label class="span-all">Description <textarea class="admin-input" name="description">{artwork?.description ?? ''}</textarea></label>
+	</FormFieldset>
+
+	<FormFieldset legend="Dimensions" layout="columns">
+		<label>Width <input class="admin-input" name="width" type="number" min="0" step="any" value={artwork?.width ?? ''} /></label>
+		<label>Height <input class="admin-input" name="height" type="number" min="0" step="any" value={artwork?.height ?? ''} /></label>
+		<label>Depth <input class="admin-input" name="depth" type="number" min="0" step="any" value={artwork?.depth ?? ''} /></label>
+		<label>Unit
+			<select class="admin-input" name="dimensionUnit">
+				<option selected={(artwork?.dimensionUnit ?? 'in') === 'in'}>in</option>
+				<option selected={artwork?.dimensionUnit === 'cm'}>cm</option>
+			</select>
+		</label>
+	</FormFieldset>
+
+	<FormFieldset legend="Images">
+		<label class="upload">Add images
+			<input class="admin-input" name="imageFiles" type="file" accept="image/jpeg,image/png,image/webp,image/gif,image/avif" multiple />
+		</label>
+		<p class="hint">JPEG, PNG, WebP, GIF, or AVIF. Maximum 10 MB each. The piece marked Default is the cover shown everywhere else.</p>
+		<div data-image-list class="image-list"></div>
+	</FormFieldset>
+
+	<FormFieldset legend="Collections" layout="columns">
+		{collections.length === 0 ? (
+			<p class="hint">No collections yet.</p>
+		) : (
+			collections.map((collection) => (
+				<label><input type="checkbox" name="collectionIds" value={collection.id} checked={artwork?.collectionIds.includes(collection.id)} /> {collection.name}</label>
+			))
+		)}
+	</FormFieldset>
+
+	<FormFieldset legend="Private sale">
+		<label class="inline-label"><input type="checkbox" name="available" checked={(artwork?.product?.quantity ?? 0) > 0 && artwork?.product?.soldAt === null} /> Available for purchase</label>
+		<label>Private price (cents) <input class="admin-input" name="priceCents" type="number" min="1" step="1" value={artwork?.product?.price ?? ''} /></label>
+		<p class="hint">Prices are visible only in administration and Stripe Checkout.</p>
+	</FormFieldset>
+
+	{artwork ? (
+		<label class="inline-label"><input type="checkbox" name="published" checked={artwork.publishedAt !== null} /> Published</label>
+	) : (
+		<p class="hint">A new artwork is saved as a draft.</p>
+	)}
+
+	<SubmitButton label="Save artwork" />
 </form>
 
 <script is:inline>
@@ -60,14 +80,14 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 			list.replaceChildren();
 			images.forEach((image, index) => {
 				const row = document.createElement('div');
-				row.className = 'grid grid-cols-[5rem_1fr_auto_auto] gap-3 items-center';
-				const preview = document.createElement('img'); preview.src = image.url; preview.alt = ''; preview.className = 'w-20 h-20 object-cover rounded';
+				row.className = 'image-row';
+				const preview = document.createElement('img'); preview.src = image.url; preview.alt = ''; preview.className = 'image-thumb';
 				const caption = document.createElement('input'); caption.className = 'admin-input'; caption.placeholder = 'Caption'; caption.value = image.caption || '';
 				caption.addEventListener('input', () => { image.caption = caption.value || null; });
 				const label = document.createElement('label'); const radio = document.createElement('input'); radio.type = 'radio'; radio.name = 'defaultImage'; radio.checked = image.isDefault;
 				radio.addEventListener('change', () => { images.forEach((entry, i) => entry.isDefault = i === index); renderImages(); });
 				label.append(radio, ' Default');
-				const remove = document.createElement('button'); remove.type = 'button'; remove.textContent = 'Remove'; remove.className = 'underline';
+				const remove = document.createElement('button'); remove.type = 'button'; remove.textContent = 'Remove'; remove.className = 'link-button';
 				remove.addEventListener('click', () => { images.splice(index, 1); if (images.length && !images.some((entry) => entry.isDefault)) images[0].isDefault = true; renderImages(); });
 				row.append(preview, caption, label, remove); list.append(row);
 			});
@@ -102,4 +122,33 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 	}
 </script>
 
-<style>.admin-input { display:block; width:100%; border:1px solid #9ca3af; border-radius:.375rem; padding:.5rem; background:transparent; }</style>
+<style>
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 1.75rem;
+		margin-top: 2.5rem;
+	}
+
+	.span-all {
+		grid-column: 1 / -1;
+	}
+
+	.image-list {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.image-list:empty::after {
+		content: 'No images yet.';
+		font-size: 0.8rem;
+		color: var(--muted);
+	}
+
+	.upload :global(.admin-input) {
+		padding: 0.6rem 0;
+		background: none;
+		border: 0;
+	}
+</style>

--- a/code/src/components/admin/ArtworkForm.astro
+++ b/code/src/components/admin/ArtworkForm.astro
@@ -75,7 +75,7 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 		let images = JSON.parse(form.dataset.images || '[]');
 		const list = form.querySelector('[data-image-list]');
 		const errorBox = form.querySelector('[data-error]');
-		const showError = (message) => { errorBox.textContent = message; errorBox.hidden = false; };
+		const showError = (message) => { errorBox.hidden = false; errorBox.textContent = message; };
 		const renderImages = () => {
 			list.replaceChildren();
 			images.forEach((image, index) => {

--- a/code/src/components/admin/CardCaption.astro
+++ b/code/src/components/admin/CardCaption.astro
@@ -35,5 +35,5 @@ const { title, meta, metaTone = 'default' } = Astro.props;
 		white-space: nowrap;
 	}
 
-	.card-meta.seal { color: var(--seal); }
+	.card-meta.seal { color: var(--seal-text); }
 </style>

--- a/code/src/components/admin/CollectionForm.astro
+++ b/code/src/components/admin/CollectionForm.astro
@@ -52,7 +52,7 @@ const { action, collection, artworks } = Astro.props;
 		try {
 			const response = await fetch(form.dataset.action, { method:'POST', headers:{'content-type':'application/json'}, body:JSON.stringify(payload) });
 			const result = await response.json(); if (!response.ok) throw new Error(result.error || 'Save failed'); window.location.assign(result.redirect);
-		} catch (error) { errorBox.textContent = error instanceof Error ? error.message : 'Save failed'; errorBox.hidden = false; }
+		} catch (error) { errorBox.hidden = false; errorBox.textContent = error instanceof Error ? error.message : 'Save failed'; }
 	});
 </script>
 

--- a/code/src/components/admin/CollectionForm.astro
+++ b/code/src/components/admin/CollectionForm.astro
@@ -1,31 +1,48 @@
 ---
+import ErrorBanner from './ErrorBanner.astro';
+import FormFieldset from './FormFieldset.astro';
+import SubmitButton from './SubmitButton.astro';
 import type { SelectArtwork, SelectCollection } from '../../db';
+
 interface Props {
 	action: string;
 	collection?: SelectCollection & { artworkIds: number[]; defaultArtworkId: number | null };
 	artworks: SelectArtwork[];
 }
+
 const { action, collection, artworks } = Astro.props;
 ---
-<form data-admin-collection-form data-action={action} class="space-y-6 max-w-3xl">
-	<div data-error hidden class="border border-red-500 p-3 rounded text-red-700"></div>
-	<div class="grid sm:grid-cols-2 gap-4">
+<form data-admin-collection-form data-action={action}>
+	<ErrorBanner />
+
+	<FormFieldset legend="Collection" layout="columns">
 		<label>Name <input class="admin-input" name="name" required value={collection?.name ?? ''} /></label>
 		<label>Slug <input class="admin-input" name="slug" required pattern="[a-z0-9]+(?:-[a-z0-9]+)*" value={collection?.slug ?? ''} /></label>
-	</div>
-	<label class="block">Description <textarea class="admin-input min-h-32" name="description">{collection?.description ?? ''}</textarea></label>
-	<fieldset class="border rounded p-4 space-y-2">
-		<legend class="px-2">Artwork membership and cover</legend>
-		{artworks.map((artwork) => (
-			<div class="grid grid-cols-[1fr_auto] gap-4">
-				<label><input type="checkbox" name="artworkIds" value={artwork.id} checked={collection?.artworkIds.includes(artwork.id)} /> {artwork.title}</label>
-				<label><input type="radio" name="defaultArtworkId" value={artwork.id} checked={collection?.defaultArtworkId === artwork.id} /> Cover</label>
-			</div>
-		))}
-	</fieldset>
-	{collection ? <label class="block"><input type="checkbox" name="published" checked={collection.publishedAt !== null} /> Published</label> : <p class="text-sm">New collections are saved as drafts.</p>}
-	<button class="px-5 py-3 bg-gray-900 text-white dark:bg-white dark:text-gray-900 rounded" type="submit">Save collection</button>
+		<label class="span-all">Description <textarea class="admin-input" name="description">{collection?.description ?? ''}</textarea></label>
+	</FormFieldset>
+
+	<FormFieldset legend="Artwork membership and cover">
+		{artworks.length === 0 ? (
+			<p class="hint">No artwork yet. Add a piece before grouping one.</p>
+		) : (
+			artworks.map((artwork) => (
+				<div class="member">
+					<label><input type="checkbox" name="artworkIds" value={artwork.id} checked={collection?.artworkIds.includes(artwork.id)} /> {artwork.title}</label>
+					<label><input type="radio" name="defaultArtworkId" value={artwork.id} checked={collection?.defaultArtworkId === artwork.id} /> Cover</label>
+				</div>
+			))
+		)}
+	</FormFieldset>
+
+	{collection ? (
+		<label class="inline-label"><input type="checkbox" name="published" checked={collection.publishedAt !== null} /> Published</label>
+	) : (
+		<p class="hint">A new collection is saved as a draft.</p>
+	)}
+
+	<SubmitButton label="Save collection" />
 </form>
+
 <script is:inline>
 	const form = document.querySelector('[data-admin-collection-form]');
 	if (form) form.addEventListener('submit', async (event) => {
@@ -38,4 +55,27 @@ const { action, collection, artworks } = Astro.props;
 		} catch (error) { errorBox.textContent = error instanceof Error ? error.message : 'Save failed'; errorBox.hidden = false; }
 	});
 </script>
-<style>.admin-input { display:block; width:100%; border:1px solid #9ca3af; border-radius:.375rem; padding:.5rem; background:transparent; }</style>
+
+<style>
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 1.75rem;
+		margin-top: 2.5rem;
+	}
+
+	.member {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: 1rem;
+		padding: 0.35rem 0;
+	}
+
+	.member + .member {
+		border-top: 1px solid rgba(236, 231, 221, 0.08);
+	}
+
+	.span-all {
+		grid-column: 1 / -1;
+	}
+</style>

--- a/code/src/components/admin/ConsoleSection.astro
+++ b/code/src/components/admin/ConsoleSection.astro
@@ -48,7 +48,7 @@ const { index, title, tally, links = [] } = Astro.props;
 		margin-right: 0.75rem;
 		font-size: 0.75rem;
 		letter-spacing: 0.2em;
-		color: var(--seal);
+		color: var(--seal-text);
 		vertical-align: 0.35em;
 	}
 
@@ -75,7 +75,7 @@ const { index, title, tally, links = [] } = Astro.props;
 	}
 
 	.ghost:hover {
-		color: var(--seal);
+		color: var(--seal-text);
 	}
 
 </style>

--- a/code/src/components/admin/ConsoleShell.astro
+++ b/code/src/components/admin/ConsoleShell.astro
@@ -125,6 +125,156 @@ const {
 		color: var(--muted);
 	}
 
+	/* Form chrome is global rather than scoped because ArtworkForm builds its
+	   image rows in a script, and script-created elements carry no scope id. */
+	.console form {
+		max-width: 56rem;
+	}
+
+	.console label {
+		display: block;
+		font-size: 0.72rem;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		color: var(--muted);
+	}
+
+	.console .admin-input {
+		display: block;
+		width: 100%;
+		margin-top: 0.5rem;
+		padding: 0.7rem 0.85rem;
+		font: inherit;
+		font-size: 0.95rem;
+		letter-spacing: normal;
+		text-transform: none;
+		color: var(--paper);
+		background: rgba(8, 8, 10, 0.6);
+		border: 1px solid var(--hair);
+		border-radius: 0;
+		transition: border-color 200ms;
+	}
+
+	.console .admin-input:hover {
+		border-color: rgba(236, 231, 221, 0.32);
+	}
+
+	.console .admin-input:focus-visible {
+		border-color: var(--seal);
+	}
+
+	.console textarea.admin-input {
+		min-height: 8rem;
+		resize: vertical;
+	}
+
+	.console fieldset {
+		margin: 0;
+		padding: clamp(1rem, 2.5vw, 1.75rem);
+		border: 1px solid var(--hair);
+	}
+
+	.console legend {
+		padding: 0 0.75rem;
+		font-size: 0.72rem;
+		letter-spacing: 0.28em;
+		text-transform: uppercase;
+		color: var(--seal);
+	}
+
+	/* A label wrapping a checkbox or radio reads as one line with its control;
+	   a label wrapping a text field stacks above it. */
+	.console label:has(input[type="checkbox"]),
+	.console label:has(input[type="radio"]),
+	.console .inline-label {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-size: 0.85rem;
+		letter-spacing: 0.06em;
+		text-transform: none;
+		color: var(--paper);
+	}
+
+	.console input[type="checkbox"],
+	.console input[type="radio"] {
+		accent-color: var(--seal);
+		width: 1rem;
+		height: 1rem;
+		flex: none;
+	}
+
+	.console input[type="file"] {
+		font-size: 0.85rem;
+		color: var(--muted);
+		text-transform: none;
+		letter-spacing: normal;
+	}
+
+	.console .submit {
+		padding: 0.9rem 2rem;
+		font: inherit;
+		font-size: 0.85rem;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: var(--paper);
+		background: var(--seal);
+		border: 1px solid var(--seal);
+		cursor: pointer;
+		transition: background 200ms, color 200ms;
+	}
+
+	.console .submit:hover {
+		background: transparent;
+		color: var(--seal);
+	}
+
+	.console .error-banner {
+		padding: 0.9rem 1.1rem;
+		font-size: 0.85rem;
+		color: var(--paper);
+		background: rgba(193, 69, 44, 0.16);
+		border: 1px solid var(--seal);
+	}
+
+	.console .hint {
+		font-size: 0.8rem;
+		letter-spacing: normal;
+		text-transform: none;
+		color: var(--muted);
+	}
+
+	/* One row per stored image, built by ArtworkForm's script. */
+	.console .image-row {
+		display: grid;
+		grid-template-columns: 5rem 1fr auto auto;
+		gap: 1rem;
+		align-items: center;
+	}
+
+	.console .image-thumb {
+		width: 5rem;
+		height: 5rem;
+		object-fit: cover;
+		border: 1px solid var(--hair);
+	}
+
+	.console .link-button {
+		font: inherit;
+		font-size: 0.72rem;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		color: var(--muted);
+		background: none;
+		border: 0;
+		cursor: pointer;
+		transition: color 200ms;
+	}
+
+	.console .link-button:hover {
+		color: var(--seal);
+	}
+
 	@media (prefers-reduced-motion: reduce) {
 		.console .wrap > * { animation: none; }
 	}

--- a/code/src/components/admin/ConsoleShell.astro
+++ b/code/src/components/admin/ConsoleShell.astro
@@ -63,6 +63,12 @@ const {
 		--muted: rgba(236, 231, 221, 0.55);
 		--hair: rgba(236, 231, 221, 0.16);
 		--seal: #c1452c;
+		/* The accent needs three values, not one: #c1452c reads as a border or a
+		   large glyph, but paper on it is 4.10:1 and it on the ground is 4.03:1 --
+		   both under AA for the small text that uses them. Darken to fill, lighten
+		   to write. */
+		--seal-fill: #a93b24;
+		--seal-text: #d4523a;
 	}
 
 	/* The console paints its own near-black ground, so it owes the keyboard a
@@ -150,13 +156,14 @@ const {
 		text-transform: none;
 		color: var(--paper);
 		background: rgba(8, 8, 10, 0.6);
-		border: 1px solid var(--hair);
+		/* A control's boundary owes 3:1; --hair is a decorative edge at 1.4:1. */
+		border: 1px solid rgba(236, 231, 221, 0.45);
 		border-radius: 0;
 		transition: border-color 200ms;
 	}
 
 	.console .admin-input:hover {
-		border-color: rgba(236, 231, 221, 0.32);
+		border-color: rgba(236, 231, 221, 0.7);
 	}
 
 	.console .admin-input:focus-visible {
@@ -179,7 +186,7 @@ const {
 		font-size: 0.72rem;
 		letter-spacing: 0.28em;
 		text-transform: uppercase;
-		color: var(--seal);
+		color: var(--seal-text);
 	}
 
 	/* A label wrapping a checkbox or radio reads as one line with its control;
@@ -218,15 +225,15 @@ const {
 		letter-spacing: 0.22em;
 		text-transform: uppercase;
 		color: var(--paper);
-		background: var(--seal);
-		border: 1px solid var(--seal);
+		background: var(--seal-fill);
+		border: 1px solid var(--seal-fill);
 		cursor: pointer;
 		transition: background 200ms, color 200ms;
 	}
 
 	.console .submit:hover {
 		background: transparent;
-		color: var(--seal);
+		color: var(--seal-text);
 	}
 
 	.console .error-banner {
@@ -272,7 +279,7 @@ const {
 	}
 
 	.console .link-button:hover {
-		color: var(--seal);
+		color: var(--seal-text);
 	}
 
 	@media (prefers-reduced-motion: reduce) {
@@ -328,7 +335,7 @@ const {
 		font-size: 0.7rem;
 		text-transform: uppercase;
 		letter-spacing: 0.42em;
-		color: var(--seal);
+		color: var(--seal-text);
 	}
 
 	.back {

--- a/code/src/components/admin/CreateAction.astro
+++ b/code/src/components/admin/CreateAction.astro
@@ -75,7 +75,7 @@ const { href, title, note } = Astro.props;
 
 	.action:hover .action-arrow {
 		transform: translateX(0.35rem);
-		color: var(--seal);
+		color: var(--seal-text);
 	}
 
 

--- a/code/src/components/admin/ErrorBanner.astro
+++ b/code/src/components/admin/ErrorBanner.astro
@@ -2,4 +2,4 @@
 // Where a form reports a failed save. Both admin forms find it by [data-error]
 // and write into it, so the hook stays on this element.
 ---
-<div data-error hidden class="error-banner" role="alert" aria-live="polite"></div>
+<div data-error hidden class="error-banner" role="alert"></div>

--- a/code/src/components/admin/ErrorBanner.astro
+++ b/code/src/components/admin/ErrorBanner.astro
@@ -1,0 +1,5 @@
+---
+// Where a form reports a failed save. Both admin forms find it by [data-error]
+// and write into it, so the hook stays on this element.
+---
+<div data-error hidden class="error-banner" role="alert" aria-live="polite"></div>

--- a/code/src/components/admin/FormFieldset.astro
+++ b/code/src/components/admin/FormFieldset.astro
@@ -1,0 +1,28 @@
+---
+// A named group of fields. The console's fieldset and legend chrome lives in
+// ConsoleShell, so this only carries the grouping and its inner rhythm.
+interface Props {
+	legend: string;
+	layout?: 'stack' | 'columns';
+}
+
+const { legend, layout = 'stack' } = Astro.props;
+---
+<fieldset>
+	<legend>{legend}</legend>
+	<div class:list={['fields', layout]}><slot /></div>
+</fieldset>
+
+<style>
+	.fields.stack {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.fields.columns {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
+		gap: 1rem;
+	}
+</style>

--- a/code/src/components/admin/SubmitButton.astro
+++ b/code/src/components/admin/SubmitButton.astro
@@ -1,0 +1,8 @@
+---
+interface Props {
+	label: string;
+}
+
+const { label } = Astro.props;
+---
+<button type="submit" class="submit">{label}</button>

--- a/code/src/pages/admin/artworks/[slug].astro
+++ b/code/src/pages/admin/artworks/[slug].astro
@@ -1,16 +1,27 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
 import ArtworkForm from '../../../components/admin/ArtworkForm.astro';
+import ConsoleShell from '../../../components/admin/ConsoleShell.astro';
 import { getAdminArtwork, getAdminCollections } from '../../../db/admin';
 import { requireAdminPage } from '../../../lib/admin-guard';
 import { getRuntimeEnv } from '../../../lib/runtime-env';
+
 export const prerender = false;
+
 const env = getRuntimeEnv();
 const access = await requireAdminPage(Astro.request, env, Astro.url.pathname);
 if ('response' in access) return access.response;
+const { session } = access;
 const slug = Astro.params.slug;
 if (!slug) return new Response('Not found', { status: 404 });
 const [artwork, collections] = await Promise.all([getAdminArtwork(env, slug), getAdminCollections(env)]);
 if (!artwork) return new Response('Not found', { status: 404 });
 ---
-<BaseLayout title={`Edit ${artwork.title} — EONMUN`}><main class="container mx-auto px-4 py-8"><h1 class="text-4xl font-bold mb-8">Edit artwork</h1><ArtworkForm action={`/api/admin/artworks/${slug}`} artwork={artwork} collections={collections} /></main></BaseLayout>
+<ConsoleShell
+	title={`Edit ${artwork.title} — EONMUN admin`}
+	heading={artwork.title}
+	email={session.user.email}
+	backHref="/admin/artworks"
+	backLabel="Artwork"
+>
+	<ArtworkForm action={`/api/admin/artworks/${slug}`} artwork={artwork} collections={collections} />
+</ConsoleShell>

--- a/code/src/pages/admin/artworks/new.astro
+++ b/code/src/pages/admin/artworks/new.astro
@@ -1,13 +1,24 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
 import ArtworkForm from '../../../components/admin/ArtworkForm.astro';
+import ConsoleShell from '../../../components/admin/ConsoleShell.astro';
 import { getAdminCollections } from '../../../db/admin';
 import { requireAdminPage } from '../../../lib/admin-guard';
 import { getRuntimeEnv } from '../../../lib/runtime-env';
+
 export const prerender = false;
+
 const env = getRuntimeEnv();
 const access = await requireAdminPage(Astro.request, env, '/admin/artworks/new');
 if ('response' in access) return access.response;
+const { session } = access;
 const collections = await getAdminCollections(env);
 ---
-<BaseLayout title="New artwork — EONMUN"><main class="container mx-auto px-4 py-8"><h1 class="text-4xl font-bold mb-8">New artwork</h1><ArtworkForm action="/api/admin/artworks" collections={collections} /></main></BaseLayout>
+<ConsoleShell
+	title="New artwork — EONMUN admin"
+	heading="New artwork"
+	email={session.user.email}
+	backHref="/admin/artworks"
+	backLabel="Artwork"
+>
+	<ArtworkForm action="/api/admin/artworks" collections={collections} />
+</ConsoleShell>

--- a/code/src/pages/admin/collections/[slug].astro
+++ b/code/src/pages/admin/collections/[slug].astro
@@ -1,16 +1,27 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
 import CollectionForm from '../../../components/admin/CollectionForm.astro';
+import ConsoleShell from '../../../components/admin/ConsoleShell.astro';
 import { getAdminArtworks, getAdminCollection } from '../../../db/admin';
 import { requireAdminPage } from '../../../lib/admin-guard';
 import { getRuntimeEnv } from '../../../lib/runtime-env';
+
 export const prerender = false;
+
 const env = getRuntimeEnv();
 const access = await requireAdminPage(Astro.request, env, Astro.url.pathname);
 if ('response' in access) return access.response;
+const { session } = access;
 const slug = Astro.params.slug;
 if (!slug) return new Response('Not found', { status: 404 });
 const [collection, artworks] = await Promise.all([getAdminCollection(env, slug), getAdminArtworks(env)]);
 if (!collection) return new Response('Not found', { status: 404 });
 ---
-<BaseLayout title={`Edit ${collection.name} — EONMUN`}><main class="container mx-auto px-4 py-8"><h1 class="text-4xl font-bold mb-8">Edit collection</h1><CollectionForm action={`/api/admin/collections/${slug}`} collection={collection} artworks={artworks} /></main></BaseLayout>
+<ConsoleShell
+	title={`Edit ${collection.name} — EONMUN admin`}
+	heading={collection.name}
+	email={session.user.email}
+	backHref="/admin/collections"
+	backLabel="Collections"
+>
+	<CollectionForm action={`/api/admin/collections/${slug}`} collection={collection} artworks={artworks} />
+</ConsoleShell>

--- a/code/src/pages/admin/collections/new.astro
+++ b/code/src/pages/admin/collections/new.astro
@@ -1,13 +1,24 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
 import CollectionForm from '../../../components/admin/CollectionForm.astro';
+import ConsoleShell from '../../../components/admin/ConsoleShell.astro';
 import { getAdminArtworks } from '../../../db/admin';
 import { requireAdminPage } from '../../../lib/admin-guard';
 import { getRuntimeEnv } from '../../../lib/runtime-env';
+
 export const prerender = false;
+
 const env = getRuntimeEnv();
 const access = await requireAdminPage(Astro.request, env, '/admin/collections/new');
 if ('response' in access) return access.response;
+const { session } = access;
 const artworks = await getAdminArtworks(env);
 ---
-<BaseLayout title="New collection — EONMUN"><main class="container mx-auto px-4 py-8"><h1 class="text-4xl font-bold mb-8">New collection</h1><CollectionForm action="/api/admin/collections" artworks={artworks} /></main></BaseLayout>
+<ConsoleShell
+	title="New collection — EONMUN admin"
+	heading="New collection"
+	email={session.user.email}
+	backHref="/admin/collections"
+	backLabel="Collections"
+>
+	<CollectionForm action="/api/admin/collections" artworks={artworks} />
+</ConsoleShell>


### PR DESCRIPTION
## What

Completes the console: every admin surface is now themed and built from the shared components.

Before this, clicking any card on the dark console dropped you into a light-mode Tailwind form with no route back. The four editor pages — `/admin/artworks/new`, `/admin/artworks/[slug]`, `/admin/collections/new`, `/admin/collections/[slug]` — now render through `ConsoleShell` with a back link to their list, and the page heading is the piece's own title.

## Shared form primitives

| Component | Owns |
| --- | --- |
| `FormFieldset` | a named group of fields, stacked or in columns |
| `ErrorBanner` | the save-failure banner both forms already wrote into via `[data-error]` |
| `SubmitButton` | the seal-filled submit |

Form chrome (inputs, labels, fieldsets, checkboxes, the image rows) lives in `ConsoleShell`'s global block rather than in either form. That is deliberate: `ArtworkForm` builds its image rows in a script, and script-created elements carry no Astro scope id, so scoped styles would not reach them.

A label wrapping a checkbox or radio reads inline with its control; a label wrapping a text field stacks above it — selected with `:has()` rather than by position, so a field moving between fieldsets keeps its layout.

## Behavior is untouched

Both forms keep their `data-*` hooks and every field `name` exactly as before — only class names changed. Upload, caption editing, default-image selection, removal, and the submit payload are the same code.

## Verification

- `bun run build` passes; `bun test` 62 pass, 0 fail.
- All seven admin routes render locally against a seeded database.
- **A real save was exercised end to end**: edited `camelia` through the restyled form, submitted, and confirmed the write landed in the database (`year` 2024 → 2023, `width` → 19). That is the risk this change carried, so it was tested rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWkvt4PUhp5xVW7AE7U18B