### PR TITLE
feat(admin): create a collection inline from the artwork editor

### DIFF
--- a/code/bun.lock
+++ b/code/bun.lock
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.3.0",
+        "happy-dom": "^20.11.2",
         "tailwindcss": "^4.3.0",
         "wrangler": "^4.90.1",
       },
@@ -355,6 +356,8 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
@@ -382,6 +385,8 @@
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -455,7 +460,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.21.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-wE4fDO8OjJhrPFH69HUQStq5oKvGRTNXEyW+k5C/pUQLASSsTu7obd2V3GvCDgPcY9AWjhJ4jz9Kh7iRvrxhJg=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
@@ -510,6 +515,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
+
+    "happy-dom": ["happy-dom@20.11.2", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw=="],
 
     "hast-util-from-html": ["hast-util-from-html@2.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.1.0", "hast-util-from-parse5": "^8.0.0", "parse5": "^7.0.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" } }, "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw=="],
 
@@ -939,13 +946,15 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
 
     "workerd": ["workerd@1.20260515.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260515.1", "@cloudflare/workerd-darwin-arm64": "1.20260515.1", "@cloudflare/workerd-linux-64": "1.20260515.1", "@cloudflare/workerd-linux-arm64": "1.20260515.1", "@cloudflare/workerd-windows-64": "1.20260515.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ=="],
 
     "wrangler": ["wrangler@4.92.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260515.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260515.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260515.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
@@ -961,7 +970,11 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@cloudflare/vite-plugin/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@libsql/isomorphic-ws/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -991,7 +1004,11 @@
 
     "libsql/detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
 
+    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 

--- a/code/package.json
+++ b/code/package.json
@@ -28,6 +28,7 @@
 	"devDependencies": {
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.3.0",
+		"happy-dom": "^20.11.2",
 		"tailwindcss": "^4.3.0",
 		"wrangler": "^4.90.1"
 	},

--- a/code/src/components/admin/ArtworkForm.astro
+++ b/code/src/components/admin/ArtworkForm.astro
@@ -58,14 +58,32 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 		<div data-image-list class="image-list"></div>
 	</FormFieldset>
 
-	<FormFieldset legend="Collections" layout="columns">
-		{collections.length === 0 ? (
-			<p class="hint">No collections yet.</p>
-		) : (
-			collections.map((collection) => (
-				<label><input type="checkbox" name="collectionIds" value={collection.id} checked={artwork?.collectionIds.includes(collection.id)} /> {collection.name}</label>
-			))
-		)}
+	<FormFieldset legend="Collections">
+		<div class="collection-list" data-collection-list>
+			{collections.length === 0 ? (
+				<p class="hint" data-collection-empty>No collections yet.</p>
+			) : (
+				collections.map((collection) => (
+					<label><input type="checkbox" name="collectionIds" value={collection.id} checked={artwork?.collectionIds.includes(collection.id)} /> {collection.name}</label>
+				))
+			)}
+		</div>
+		<div class="new-collection">
+			<label for="new-collection-name">New collection</label>
+			<div class="new-collection-row">
+				<input
+					class="admin-input"
+					id="new-collection-name"
+					type="text"
+					autocomplete="off"
+					placeholder="Collection name"
+					aria-describedby="new-collection-status"
+					data-new-collection-name
+				/>
+				<button type="button" class="add-collection" data-new-collection-add>+ New</button>
+			</div>
+			<p id="new-collection-status" class="hint" role="status" aria-live="polite" data-new-collection-status></p>
+		</div>
 	</FormFieldset>
 
 	<FormFieldset legend="Private sale">
@@ -108,6 +126,59 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 		const syncPriceRequirement = () => { price.required = available.checked; };
 		available.addEventListener('change', syncPriceRequirement);
 		syncPriceRequirement();
+
+		// Inline collection creation. The artwork's own save is the only writer of
+		// membership, so the new collection is created empty and its checkbox is
+		// ticked here; saving the artwork attaches it.
+		const collectionList = form.querySelector('[data-collection-list]');
+		const newName = form.querySelector('[data-new-collection-name]');
+		const newButton = form.querySelector('[data-new-collection-add]');
+		const newStatus = form.querySelector('[data-new-collection-status]');
+		const setCollectionStatus = (message, failed) => {
+			newStatus.textContent = message;
+			newStatus.classList.toggle('is-error', Boolean(failed));
+		};
+		const createCollection = async () => {
+			const name = newName.value.trim();
+			if (!name) { setCollectionStatus('Type a collection name first.', true); newName.focus(); return; }
+			newButton.disabled = true;
+			setCollectionStatus('Creating the collection.', false);
+			try {
+				const response = await fetch('/api/admin/collections', {
+					method: 'POST',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ name, published: false, artworkIds: [] }),
+				});
+				const result = await response.json();
+				if (!response.ok) throw new Error(result.error || 'Could not create the collection');
+				// CRITICAL: the endpoint also answers with a redirect target for the
+				// collection form. Following it here would throw away every unsaved
+				// edit on this artwork.
+				const empty = collectionList.querySelector('[data-collection-empty]');
+				if (empty) empty.remove();
+				const label = document.createElement('label');
+				const checkbox = document.createElement('input');
+				checkbox.type = 'checkbox'; checkbox.name = 'collectionIds'; checkbox.value = String(result.collection.id); checkbox.checked = true;
+				label.append(checkbox, ' ' + result.collection.name);
+				collectionList.append(label);
+				newName.value = '';
+				setCollectionStatus(result.collection.name + ' is added and ticked. Save the artwork to file it.', false);
+				checkbox.focus();
+			} catch (error) {
+				setCollectionStatus(error instanceof Error ? error.message : 'Could not create the collection', true);
+				newName.focus();
+			} finally {
+				newButton.disabled = false;
+			}
+		};
+		newButton.addEventListener('click', createCollection);
+		// The field sits inside the artwork form, so Enter would otherwise submit
+		// and save the whole artwork.
+		newName.addEventListener('keydown', (event) => {
+			if (event.key !== 'Enter') return;
+			event.preventDefault();
+			createCollection();
+		});
 
 		const renderImages = () => {
 			list.replaceChildren();
@@ -165,6 +236,64 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 
 	.span-all {
 		grid-column: 1 / -1;
+	}
+
+	/* Matches FormFieldset's `columns` layout. The checkboxes need a container of
+	   their own so the script has one insertion point on both the populated and
+	   the empty state. */
+	.collection-list {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
+		gap: 1rem;
+	}
+
+	.new-collection-row {
+		display: flex;
+		align-items: stretch;
+		gap: 0.75rem;
+		margin-top: 0.5rem;
+	}
+
+	.new-collection-row .admin-input {
+		margin-top: 0;
+	}
+
+	.add-collection {
+		flex: none;
+		padding: 0 1.1rem;
+		font: inherit;
+		font-size: 0.72rem;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		white-space: nowrap;
+		color: var(--paper);
+		background: transparent;
+		/* A control boundary owes 3:1 against the console ground; --hair does not
+		   reach it. */
+		border: 1px solid rgba(236, 231, 221, 0.45);
+		cursor: pointer;
+		transition: background 200ms, border-color 200ms, color 200ms;
+	}
+
+	.add-collection:hover:not(:disabled) {
+		background: var(--seal-fill);
+		border-color: var(--seal-fill);
+	}
+
+	.add-collection:disabled {
+		color: var(--muted);
+		cursor: progress;
+	}
+
+	/* The live region stays in the layout at all times. A region that is hidden
+	   until it has text is not reliably announced when the text arrives. */
+	.new-collection .hint {
+		min-height: 1.2em;
+		margin-top: 0.5rem;
+	}
+
+	.new-collection .hint.is-error {
+		color: var(--seal-text);
 	}
 
 	.image-list {

--- a/code/src/components/admin/ArtworkForm.astro
+++ b/code/src/components/admin/ArtworkForm.astro
@@ -77,7 +77,6 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 					type="text"
 					autocomplete="off"
 					placeholder="Collection name"
-					aria-describedby="new-collection-status"
 					data-new-collection-name
 				/>
 				<button type="button" class="add-collection" data-new-collection-add>+ New</button>
@@ -127,59 +126,6 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 		available.addEventListener('change', syncPriceRequirement);
 		syncPriceRequirement();
 
-		// Inline collection creation. The artwork's own save is the only writer of
-		// membership, so the new collection is created empty and its checkbox is
-		// ticked here; saving the artwork attaches it.
-		const collectionList = form.querySelector('[data-collection-list]');
-		const newName = form.querySelector('[data-new-collection-name]');
-		const newButton = form.querySelector('[data-new-collection-add]');
-		const newStatus = form.querySelector('[data-new-collection-status]');
-		const setCollectionStatus = (message, failed) => {
-			newStatus.textContent = message;
-			newStatus.classList.toggle('is-error', Boolean(failed));
-		};
-		const createCollection = async () => {
-			const name = newName.value.trim();
-			if (!name) { setCollectionStatus('Type a collection name first.', true); newName.focus(); return; }
-			newButton.disabled = true;
-			setCollectionStatus('Creating the collection.', false);
-			try {
-				const response = await fetch('/api/admin/collections', {
-					method: 'POST',
-					headers: { 'content-type': 'application/json' },
-					body: JSON.stringify({ name, published: false, artworkIds: [] }),
-				});
-				const result = await response.json();
-				if (!response.ok) throw new Error(result.error || 'Could not create the collection');
-				// CRITICAL: the endpoint also answers with a redirect target for the
-				// collection form. Following it here would throw away every unsaved
-				// edit on this artwork.
-				const empty = collectionList.querySelector('[data-collection-empty]');
-				if (empty) empty.remove();
-				const label = document.createElement('label');
-				const checkbox = document.createElement('input');
-				checkbox.type = 'checkbox'; checkbox.name = 'collectionIds'; checkbox.value = String(result.collection.id); checkbox.checked = true;
-				label.append(checkbox, ' ' + result.collection.name);
-				collectionList.append(label);
-				newName.value = '';
-				setCollectionStatus(result.collection.name + ' is added and ticked. Save the artwork to file it.', false);
-				checkbox.focus();
-			} catch (error) {
-				setCollectionStatus(error instanceof Error ? error.message : 'Could not create the collection', true);
-				newName.focus();
-			} finally {
-				newButton.disabled = false;
-			}
-		};
-		newButton.addEventListener('click', createCollection);
-		// The field sits inside the artwork form, so Enter would otherwise submit
-		// and save the whole artwork.
-		newName.addEventListener('keydown', (event) => {
-			if (event.key !== 'Enter') return;
-			event.preventDefault();
-			createCollection();
-		});
-
 		const renderImages = () => {
 			list.replaceChildren();
 			images.forEach((image, index) => {
@@ -224,6 +170,15 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 		});
 		renderImages();
 	}
+</script>
+
+<script>
+	// Bundled, not `is:inline`: an inline script cannot import, and the inline
+	// collection creator is covered by a test that imports the same module.
+	import { attachInlineCollectionCreator } from '../../lib/inline-collection-creator';
+
+	const artworkForm = document.querySelector('[data-admin-artwork-form]');
+	if (artworkForm instanceof HTMLFormElement) attachInlineCollectionCreator(artworkForm);
 </script>
 
 <style>
@@ -275,12 +230,14 @@ const images = artwork?.images.map(({ url, caption, isDefault }) => ({ url, capt
 		transition: background 200ms, border-color 200ms, color 200ms;
 	}
 
-	.add-collection:hover:not(:disabled) {
+	.add-collection:hover:not([aria-disabled='true']) {
 		background: var(--seal-fill);
 		border-color: var(--seal-fill);
 	}
 
-	.add-collection:disabled {
+	/* The in-flight state is `aria-disabled`, not `disabled`, so the button keeps
+	   its place in the focus order. The handler refuses the second activation. */
+	.add-collection[aria-disabled='true'] {
 		color: var(--muted);
 		cursor: progress;
 	}

--- a/code/src/lib/admin-guard.ts
+++ b/code/src/lib/admin-guard.ts
@@ -32,12 +32,29 @@ export async function requireAdminPage(request: Request, env: AuthEnv, callbackP
 		: { response: redirectResponse(getSignInUrl(request, callbackPath), 302) };
 }
 
+// Drizzle wraps a driver failure as "Failed query: <sql> params: <values>" and
+// keeps the driver's own error as the cause, so the constraint text a slug
+// collision is recognised by is never in the outermost message.
+function errorMessages(error: unknown) {
+	const messages: string[] = [];
+	let current: unknown = error;
+	while (current instanceof Error && messages.length < 5) {
+		messages.push(current.message);
+		current = (current as { cause?: unknown }).cause;
+	}
+	return messages;
+}
+
 export function mutationError(error: unknown) {
-	const message = error instanceof Error ? error.message : "Mutation failed";
-	const conflict = /unique constraint failed:[^\n]*\bslug\b/i.test(message) ||
-		/SQLITE_CONSTRAINT_UNIQUE[^\n]*\bslug\b/i.test(message);
+	const messages = errorMessages(error);
+	const conflict = messages.some((message) =>
+		/unique constraint failed:[^\n]*\bslug\b/i.test(message) ||
+		/SQLITE_CONSTRAINT_UNIQUE[^\n]*\bslug\b/i.test(message));
+	// SECURITY: the wrapper message repeats the statement and every bound
+	// parameter back to the caller. Report the driver's message instead.
+	const reported = messages.find((message) => !message.startsWith("Failed query:")) ?? "Mutation failed";
 	return Response.json(
-		{ error: conflict ? "Slug already exists" : message },
+		{ error: conflict ? "Slug already exists" : reported },
 		{ status: conflict ? 409 : 400 },
 	);
 }

--- a/code/src/lib/admin-input.ts
+++ b/code/src/lib/admin-input.ts
@@ -92,15 +92,22 @@ export interface CollectionAdminInput {
 	defaultArtworkId: number | null;
 }
 
-export function parseCollectionInput(value: unknown): CollectionAdminInput {
+export interface CollectionParseOptions {
+	// CRITICAL: opt-in, and only for creation. A collection's slug is its public
+	// URL. If an update could derive one, a body that carried a renamed `name`
+	// and no slug key would silently move a published collection's address
+	// instead of being rejected.
+	deriveSlug?: boolean;
+}
+
+export function parseCollectionInput(value: unknown, options: CollectionParseOptions = {}): CollectionAdminInput {
 	if (!value || typeof value !== "object") throw new Error("Invalid collection payload");
 	const input = value as Record<string, unknown>;
 	const name = text(input.name, "Name", true)!;
-	// A caller that omits the slug key entirely -- the artwork editor's inline
-	// creator, which asks for a name only -- gets one derived from the name. An
-	// empty slug string is still an error, so the collection form keeps telling
+	// The artwork editor's inline creator asks for a name only. An empty slug
+	// string is still an error either way, so the collection form keeps telling
 	// an editor who cleared the field that it is required.
-	const derived = input.slug === undefined || input.slug === null;
+	const derived = options.deriveSlug === true && (input.slug === undefined || input.slug === null);
 	const slug = derived ? slugify(name) : text(input.slug, "Slug", true)!;
 	if (derived && !slug) throw new Error("Name must contain letters or numbers");
 	if (!SLUG_PATTERN.test(slug)) throw new Error("Slug must use lowercase letters, numbers, and hyphens");

--- a/code/src/lib/admin-input.ts
+++ b/code/src/lib/admin-input.ts
@@ -1,5 +1,5 @@
 import { R2_PUBLIC_ORIGIN } from "./media";
-import { SLUG_PATTERN } from "./slug";
+import { SLUG_PATTERN, slugify } from "./slug";
 
 function text(value: unknown, field: string, required = false) {
 	if (typeof value !== "string") {
@@ -95,7 +95,14 @@ export interface CollectionAdminInput {
 export function parseCollectionInput(value: unknown): CollectionAdminInput {
 	if (!value || typeof value !== "object") throw new Error("Invalid collection payload");
 	const input = value as Record<string, unknown>;
-	const slug = text(input.slug, "Slug", true)!;
+	const name = text(input.name, "Name", true)!;
+	// A caller that omits the slug key entirely -- the artwork editor's inline
+	// creator, which asks for a name only -- gets one derived from the name. An
+	// empty slug string is still an error, so the collection form keeps telling
+	// an editor who cleared the field that it is required.
+	const derived = input.slug === undefined || input.slug === null;
+	const slug = derived ? slugify(name) : text(input.slug, "Slug", true)!;
+	if (derived && !slug) throw new Error("Name must contain letters or numbers");
 	if (!SLUG_PATTERN.test(slug)) throw new Error("Slug must use lowercase letters, numbers, and hyphens");
 	const artworkIds = ids(input.artworkIds ?? [], "Artworks");
 	const defaultArtworkId = input.defaultArtworkId == null || input.defaultArtworkId === ""
@@ -105,7 +112,7 @@ export function parseCollectionInput(value: unknown): CollectionAdminInput {
 		throw new Error("The collection cover must be an artwork in the collection");
 	}
 	return {
-		name: text(input.name, "Name", true)!,
+		name,
 		slug,
 		description: text(input.description, "Description"),
 		published: input.published === true,

--- a/code/src/lib/inline-collection-creator.ts
+++ b/code/src/lib/inline-collection-creator.ts
@@ -1,0 +1,101 @@
+// Files an artwork into a brand-new collection without leaving the editor. The
+// artwork's own save is the only writer of membership, so the collection is
+// created empty here and its checkbox is ticked; saving the artwork attaches it.
+//
+// This lives in a module rather than the component's inline script so the
+// behaviour can be driven by a test.
+
+export interface InlineCollectionCreatorOptions {
+	fetchImpl?: typeof fetch;
+	endpoint?: string;
+}
+
+export function attachInlineCollectionCreator(
+	form: HTMLFormElement,
+	options: InlineCollectionCreatorOptions = {},
+) {
+	const list = form.querySelector<HTMLElement>("[data-collection-list]");
+	const nameField = form.querySelector<HTMLInputElement>("[data-new-collection-name]");
+	const button = form.querySelector<HTMLElement>("[data-new-collection-add]");
+	const status = form.querySelector<HTMLElement>("[data-new-collection-status]");
+	if (!list || !nameField || !button || !status) return;
+
+	const doc = form.ownerDocument;
+	const endpoint = options.endpoint ?? "/api/admin/collections";
+	const request: typeof fetch = options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
+	let inFlight = false;
+
+	const report = (message: string, failed: boolean) => {
+		status.textContent = message;
+		status.classList.toggle("is-error", failed);
+	};
+
+	// CRITICAL: `aria-disabled`, not the `disabled` property. A disabled button
+	// leaves the focus order, so a keyboard user who just activated this one
+	// would be dropped back to the document body until the request settles.
+	const setBusy = (busy: boolean) => {
+		inFlight = busy;
+		button.setAttribute("aria-disabled", String(busy));
+	};
+
+	const create = async () => {
+		// The click path and the Enter path both reach here, and a disabled
+		// attribute would only have stopped the first. Without this a second
+		// Enter sends a concurrent request whose 409 overwrites the success line.
+		if (inFlight) return;
+		const name = nameField.value.trim();
+		if (!name) {
+			report("Type a collection name first.", true);
+			nameField.focus();
+			return;
+		}
+		setBusy(true);
+		report("Creating the collection.", false);
+		try {
+			const response = await request(endpoint, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ name, published: false, artworkIds: [] }),
+			});
+			const result = await response.json();
+			// This control asks for a name and never shows a slug, so the server's
+			// slug wording would name a field the editor cannot see. Two names can
+			// also collide only after slugification -- "B&W" and "B W" both derive
+			// b-w -- which reads as nonsense unless the message talks about names.
+			if (response.status === 409) throw new Error("A collection with that name already exists.");
+			if (!response.ok) throw new Error(result.error || "Could not create the collection");
+			// CRITICAL: the endpoint also answers with a redirect target, for the
+			// collection form's benefit. Following it here would throw away every
+			// unsaved edit on this artwork.
+			list.querySelector("[data-collection-empty]")?.remove();
+			const label = doc.createElement("label");
+			const checkbox = doc.createElement("input");
+			checkbox.type = "checkbox";
+			checkbox.name = "collectionIds";
+			checkbox.value = String(result.collection.id);
+			checkbox.checked = true;
+			label.append(checkbox, ` ${result.collection.name}`);
+			list.append(label);
+			nameField.value = "";
+			report(`${result.collection.name} is added and ticked. Save the artwork to file it.`, false);
+			checkbox.focus();
+		} catch (error) {
+			report(error instanceof Error ? error.message : "Could not create the collection", true);
+			nameField.focus();
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	button.addEventListener("click", (event) => {
+		event.preventDefault();
+		void create();
+	});
+	nameField.addEventListener("keydown", (event) => {
+		if ((event as KeyboardEvent).key !== "Enter") return;
+		// The field sits inside the artwork form, so Enter would otherwise submit
+		// and save the whole artwork.
+		event.preventDefault();
+		void create();
+	});
+}

--- a/code/src/lib/slug.ts
+++ b/code/src/lib/slug.ts
@@ -1,2 +1,14 @@
 // Shared by admin input validation and the public checkout endpoint.
 export const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+// Derives a slug from a display name so a caller that has only a name does not
+// have to ask for both. Accents are folded rather than dropped, so "Étude"
+// keeps its letters instead of becoming "tude".
+export function slugify(value: string) {
+	return value
+		.normalize("NFKD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}

--- a/code/src/pages/api/admin/collections/index.ts
+++ b/code/src/pages/api/admin/collections/index.ts
@@ -10,7 +10,10 @@ export const POST: APIRoute = async ({ request }) => {
 	const guard = await requireAdminMutation(request, env);
 	if ("response" in guard) return guard.response;
 	try {
-		const collection = await createCollectionAdmin(env, parseCollectionInput(await request.json()));
+		// Creation may derive a slug from the name. The update route may not: that
+		// would move a published collection's public address.
+		const input = parseCollectionInput(await request.json(), { deriveSlug: true });
+		const collection = await createCollectionAdmin(env, input);
 		return Response.json({ collection, redirect: `/admin/collections/${collection.slug}` }, { status: 201 });
 	} catch (error) {
 		return mutationError(error);

--- a/code/test/admin-guard.test.ts
+++ b/code/test/admin-guard.test.ts
@@ -49,4 +49,22 @@ describe("admin request guards", () => {
 		expect(response.status).toBe(409);
 		expect(await response.json()).toEqual({ error: "Slug already exists" });
 	});
+
+	test("finds the collision inside the query wrapper the driver error is nested in", async () => {
+		const response = mutationError(new Error(
+			'Failed query: insert into "collections" ("id", "name", "slug") values (null, ?, ?)\nparams: Winter Studies,winter-studies',
+			{ cause: new Error("SQLITE_CONSTRAINT_UNIQUE: UNIQUE constraint failed: collections.slug") },
+		));
+		expect(response.status).toBe(409);
+		expect(await response.json()).toEqual({ error: "Slug already exists" });
+	});
+
+	test("never reports the query wrapper, which repeats the submitted values", async () => {
+		const response = mutationError(new Error(
+			'Failed query: insert into "collections" ("id") values (null)\nparams: Winter Studies',
+			{ cause: new Error("SQLITE_FULL: database or disk is full") },
+		));
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "SQLITE_FULL: database or disk is full" });
+	});
 });

--- a/code/test/admin-input.test.ts
+++ b/code/test/admin-input.test.ts
@@ -33,19 +33,28 @@ describe("admin input", () => {
 		expect(() => parseCollectionInput({ name: "Group", slug: "group", artworkIds: [1], defaultArtworkId: 2 })).toThrow("cover");
 	});
 
-	test("derives a collection slug when the caller sends a name only", () => {
-		const result = parseCollectionInput({ name: "  Winter Étude 2026!  ", artworkIds: [] });
+	test("derives a collection slug when the caller asks for it and sends a name only", () => {
+		const result = parseCollectionInput({ name: "  Winter Étude 2026!  ", artworkIds: [] }, { deriveSlug: true });
 		expect(result.slug).toBe("winter-etude-2026");
 		expect(result.name).toBe("Winter Étude 2026!");
 		expect(SLUG_PATTERN.test(result.slug)).toBe(true);
 	});
 
+	test("never derives a slug unless the caller opts in", () => {
+		// The update route parses without the flag. A body that renames a
+		// collection and omits the slug key must be rejected, not quietly given a
+		// new public address.
+		expect(() => parseCollectionInput({ name: "Renamed group", artworkIds: [] })).toThrow("Slug must be text");
+		expect(parseCollectionInput({ name: "Renamed group", slug: "original-group", artworkIds: [] }).slug).toBe("original-group");
+	});
+
 	test("still requires a slug the caller sent as an empty string", () => {
+		expect(() => parseCollectionInput({ name: "Group", slug: "", artworkIds: [] }, { deriveSlug: true })).toThrow("Slug is required");
 		expect(() => parseCollectionInput({ name: "Group", slug: "", artworkIds: [] })).toThrow("Slug is required");
 	});
 
 	test("rejects a name that cannot produce a slug", () => {
-		expect(() => parseCollectionInput({ name: "!!!", artworkIds: [] })).toThrow("Name must contain letters or numbers");
+		expect(() => parseCollectionInput({ name: "!!!", artworkIds: [] }, { deriveSlug: true })).toThrow("Name must contain letters or numbers");
 	});
 
 	test("slugify keeps the shape the slug pattern demands", () => {

--- a/code/test/admin-input.test.ts
+++ b/code/test/admin-input.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { parseArtworkInput, parseCollectionInput } from "../src/lib/admin-input";
+import { SLUG_PATTERN, slugify } from "../src/lib/slug";
 
 const artwork = {
 	title: "New work",
@@ -30,6 +31,27 @@ describe("admin input", () => {
 
 	test("validates collection cover membership", () => {
 		expect(() => parseCollectionInput({ name: "Group", slug: "group", artworkIds: [1], defaultArtworkId: 2 })).toThrow("cover");
+	});
+
+	test("derives a collection slug when the caller sends a name only", () => {
+		const result = parseCollectionInput({ name: "  Winter Étude 2026!  ", artworkIds: [] });
+		expect(result.slug).toBe("winter-etude-2026");
+		expect(result.name).toBe("Winter Étude 2026!");
+		expect(SLUG_PATTERN.test(result.slug)).toBe(true);
+	});
+
+	test("still requires a slug the caller sent as an empty string", () => {
+		expect(() => parseCollectionInput({ name: "Group", slug: "", artworkIds: [] })).toThrow("Slug is required");
+	});
+
+	test("rejects a name that cannot produce a slug", () => {
+		expect(() => parseCollectionInput({ name: "!!!", artworkIds: [] })).toThrow("Name must contain letters or numbers");
+	});
+
+	test("slugify keeps the shape the slug pattern demands", () => {
+		expect(slugify("Two  --  Words")).toBe("two-words");
+		expect(slugify("-leading and trailing-")).toBe("leading-and-trailing");
+		expect(slugify("")).toBe("");
 	});
 
 	test("normalizes one default image", () => {

--- a/code/test/admin-mutations.test.ts
+++ b/code/test/admin-mutations.test.ts
@@ -113,6 +113,25 @@ describe("admin mutations", () => {
 		expect(membership.isDefaultForCollection).toBe(true);
 	});
 
+	test("files an artwork into a collection created empty from a name only", async () => {
+		const artwork = await createArtworkAdmin(env, artworkInput(), db);
+		// What the artwork editor's inline creator sends: a name, no slug, and no
+		// membership. The artwork's own save is the single writer of membership.
+		const collection = await createCollectionAdmin(env, parseCollectionInput({ name: "Winter Studies" }), db);
+		expect(collection.slug).toBe("winter-studies");
+		expect(await db.select().from(artworksToCollections).where(eq(artworksToCollections.collectionId, collection.id))).toHaveLength(0);
+
+		await updateArtworkAdmin(env, artwork.slug, artworkInput({ collectionIds: [collection.id] }), db);
+
+		const memberships = await db.select().from(artworksToCollections).where(eq(artworksToCollections.collectionId, collection.id));
+		expect(memberships.map((row) => row.artworkId)).toEqual([artwork.id]);
+	});
+
+	test("rejects a second collection whose derived slug already exists", async () => {
+		await createCollectionAdmin(env, parseCollectionInput({ name: "Winter Studies" }), db);
+		await expect(createCollectionAdmin(env, parseCollectionInput({ name: "winter studies" }), db)).rejects.toThrow();
+	});
+
 	test("rolls back artwork creation if its product write fails", async () => {
 		const now = Math.floor(Date.now() / 1000);
 		await client.execute({ sql: "INSERT INTO products (type, name, slug, price, quantity, listed_at, created_at, updated_at) VALUES ('artwork', 'Collision', 'rollback', 1, 0, ?, ?, ?)", args: [now, now, now] });

--- a/code/test/admin-mutations.test.ts
+++ b/code/test/admin-mutations.test.ts
@@ -117,7 +117,7 @@ describe("admin mutations", () => {
 		const artwork = await createArtworkAdmin(env, artworkInput(), db);
 		// What the artwork editor's inline creator sends: a name, no slug, and no
 		// membership. The artwork's own save is the single writer of membership.
-		const collection = await createCollectionAdmin(env, parseCollectionInput({ name: "Winter Studies" }), db);
+		const collection = await createCollectionAdmin(env, parseCollectionInput({ name: "Winter Studies" }, { deriveSlug: true }), db);
 		expect(collection.slug).toBe("winter-studies");
 		expect(await db.select().from(artworksToCollections).where(eq(artworksToCollections.collectionId, collection.id))).toHaveLength(0);
 
@@ -128,8 +128,8 @@ describe("admin mutations", () => {
 	});
 
 	test("rejects a second collection whose derived slug already exists", async () => {
-		await createCollectionAdmin(env, parseCollectionInput({ name: "Winter Studies" }), db);
-		await expect(createCollectionAdmin(env, parseCollectionInput({ name: "winter studies" }), db)).rejects.toThrow();
+		await createCollectionAdmin(env, parseCollectionInput({ name: "Winter Studies" }, { deriveSlug: true }), db);
+		await expect(createCollectionAdmin(env, parseCollectionInput({ name: "winter studies" }, { deriveSlug: true }), db)).rejects.toThrow();
 	});
 
 	test("rolls back artwork creation if its product write fails", async () => {

--- a/code/test/inline-collection-creator.test.ts
+++ b/code/test/inline-collection-creator.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { attachInlineCollectionCreator } from "../src/lib/inline-collection-creator";
+
+// The markup the component renders around the control, reduced to the parts the
+// script reaches for. The artwork fields are here so a test can prove they
+// survive.
+const markup = (collections: string) => `
+<form data-admin-artwork-form data-action="/api/admin/artworks/camelia">
+	<input name="title" value="Camelia" />
+	<fieldset>
+		<div class="collection-list" data-collection-list>${collections}</div>
+		<div class="new-collection">
+			<label for="new-collection-name">New collection</label>
+			<input id="new-collection-name" type="text" data-new-collection-name />
+			<button type="button" data-new-collection-add>+ New</button>
+			<p id="new-collection-status" role="status" aria-live="polite" data-new-collection-status></p>
+		</div>
+	</fieldset>
+</form>`;
+
+const populated = '<label><input type="checkbox" name="collectionIds" value="3" /> Botánica</label>';
+const empty = '<p class="hint" data-collection-empty>No collections yet.</p>';
+
+let window: Window;
+let form: HTMLFormElement;
+let calls: { url: string; body: Record<string, unknown> }[];
+
+const created = (id: number, name: string) => new Response(
+	// The endpoint answers with a redirect target for the collection form.
+	// Following it here would discard the artwork's unsaved edits.
+	JSON.stringify({ collection: { id, name }, redirect: `/admin/collections/${name}` }),
+	{ status: 201, headers: { "content-type": "application/json" } },
+);
+
+const conflict = () => new Response(
+	JSON.stringify({ error: "Slug already exists" }),
+	{ status: 409, headers: { "content-type": "application/json" } },
+);
+
+function mount(collections: string, respond: () => Response | Promise<Response>) {
+	window = new Window({ url: "https://admin.test/admin/artworks/camelia" });
+	window.document.body.innerHTML = markup(collections);
+	form = window.document.querySelector("[data-admin-artwork-form]") as unknown as HTMLFormElement;
+	calls = [];
+	attachInlineCollectionCreator(form, {
+		fetchImpl: (async (url: string, init: RequestInit) => {
+			calls.push({ url: String(url), body: JSON.parse(String(init.body)) });
+			return respond();
+		}) as unknown as typeof fetch,
+	});
+	return {
+		field: form.querySelector("[data-new-collection-name]") as HTMLInputElement,
+		button: form.querySelector("[data-new-collection-add]") as HTMLElement,
+		status: form.querySelector("[data-new-collection-status]") as HTMLElement,
+		list: form.querySelector("[data-collection-list]") as HTMLElement,
+	};
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const pressEnter = (field: HTMLInputElement) => {
+	const event = new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+	field.dispatchEvent(event as unknown as Event);
+	return event;
+};
+
+describe("inline collection creator", () => {
+	beforeEach(() => {
+		calls = [];
+	});
+
+	test("appends the new collection ticked, in the shape the artwork form submits", async () => {
+		const { field, button, status, list } = mount(populated, () => created(7, "Winter Studies"));
+		const before = window.location.href;
+		field.value = "Winter Studies";
+		button.click();
+		await settle();
+
+		expect(calls).toEqual([{ url: "/api/admin/collections", body: { name: "Winter Studies", published: false, artworkIds: [] } }]);
+		const boxes = [...list.querySelectorAll("input[name='collectionIds']")] as HTMLInputElement[];
+		expect(boxes.map((box) => [box.value, box.checked])).toEqual([["3", false], ["7", true]]);
+		expect(list.textContent).toContain("Winter Studies");
+		expect(status.textContent).toContain("added and ticked");
+		expect(status.classList.contains("is-error")).toBe(false);
+		expect(field.value).toBe("");
+		expect(window.document.activeElement).toBe(boxes[1] as unknown as Element);
+		// The response carried a redirect. Nothing followed it, and the artwork's
+		// own edits are untouched.
+		expect(window.location.href).toBe(before);
+		expect((form.elements as unknown as Record<string, HTMLInputElement>).title.value).toBe("Camelia");
+	});
+
+	test("the new collection is not created with the artwork already attached", async () => {
+		const { field, button } = mount(populated, () => created(7, "Winter Studies"));
+		field.value = "Winter Studies";
+		button.click();
+		await settle();
+		// updateArtworkAdmin replaces membership wholesale from the submitted
+		// collectionIds, so it must stay the only writer of membership.
+		expect(calls[0].body.artworkIds).toEqual([]);
+	});
+
+	test("replaces the empty state rather than rendering beside it", async () => {
+		const { field, button, list } = mount(empty, () => created(1, "First Group"));
+		field.value = "First Group";
+		button.click();
+		await settle();
+
+		expect(list.querySelector("[data-collection-empty]")).toBeNull();
+		expect(list.querySelectorAll("input[name='collectionIds']")).toHaveLength(1);
+	});
+
+	test("Enter creates the collection and does not submit the artwork", async () => {
+		const { field, list } = mount(populated, () => created(7, "Winter Studies"));
+		field.value = "Winter Studies";
+		const event = pressEnter(field);
+		await settle();
+
+		// preventDefault is what stops the browser's implicit form submission.
+		expect(event.defaultPrevented).toBe(true);
+		expect(calls).toHaveLength(1);
+		expect(list.querySelectorAll("input[name='collectionIds']")).toHaveLength(2);
+	});
+
+	test("a second Enter while the first is in flight sends nothing", async () => {
+		let release: (value: Response) => void = () => {};
+		const pending = new Promise<Response>((resolve) => { release = resolve; });
+		const { field, button, list, status } = mount(populated, () => pending);
+		field.value = "Winter Studies";
+
+		pressEnter(field);
+		await settle();
+		pressEnter(field);
+		pressEnter(field);
+		button.click();
+		await settle();
+		expect(calls).toHaveLength(1);
+		// The guard is the in-flight flag, not the disabled property, which would
+		// have taken the button out of the focus order.
+		expect(button.getAttribute("aria-disabled")).toBe("true");
+		expect((button as HTMLButtonElement).disabled).toBe(false);
+
+		release(created(7, "Winter Studies"));
+		await settle();
+		expect(status.textContent).toContain("added and ticked");
+		expect(list.querySelectorAll("input[name='collectionIds']")).toHaveLength(2);
+		expect(button.getAttribute("aria-disabled")).toBe("false");
+	});
+
+	test("a duplicate name reports in the caller's own vocabulary and keeps the typed name", async () => {
+		const { field, button, status, list } = mount(populated, conflict);
+		field.value = "Winter Studies";
+		button.click();
+		await settle();
+
+		// The control never shows a slug, so the server's slug wording would name
+		// a field this editor cannot see.
+		expect(status.textContent).toBe("A collection with that name already exists.");
+		expect(status.classList.contains("is-error")).toBe(true);
+		expect(field.value).toBe("Winter Studies");
+		expect(window.document.activeElement).toBe(field as unknown as Element);
+		expect(list.querySelectorAll("input[name='collectionIds']")).toHaveLength(1);
+		expect((form.elements as unknown as Record<string, HTMLInputElement>).title.value).toBe("Camelia");
+	});
+
+	test("a validation failure reports the server's message", async () => {
+		const { field, button, status } = mount(populated, () => new Response(
+			JSON.stringify({ error: "Name must contain letters or numbers" }),
+			{ status: 400, headers: { "content-type": "application/json" } },
+		));
+		field.value = "!!!";
+		button.click();
+		await settle();
+
+		expect(status.textContent).toBe("Name must contain letters or numbers");
+		expect(status.classList.contains("is-error")).toBe(true);
+	});
+
+	test("an empty name is refused without a request", async () => {
+		const { field, button, status } = mount(populated, () => created(7, "Winter Studies"));
+		field.value = "   ";
+		button.click();
+		await settle();
+
+		expect(calls).toHaveLength(0);
+		expect(status.textContent).toBe("Type a collection name first.");
+		expect(window.document.activeElement).toBe(field as unknown as Element);
+	});
+});


### PR DESCRIPTION
## What

The artwork editor's Collections fieldset gains a name field and a `+ New` button. Typing a name and pressing the button (or Enter) creates the collection and drops its checkbox into the list, already ticked, without leaving the page. The artwork's unsaved edits survive.

## Design decision: who writes the membership

`createCollectionAdmin` accepts `artworkIds`, and `updateArtworkAdmin` replaces an artwork's memberships wholesale from the submitted `collectionIds`. **Option 1 was taken:** the collection is created with `artworkIds: []`, the checkbox is ticked client-side, and the artwork's own save attaches it. `updateArtworkAdmin` stays the single writer of membership, so the two paths cannot disagree.

The clincher is the new-artwork page: `ArtworkForm` renders there too, with no artwork id to attach, so Option 2 would need a second code path for a case Option 1 handles unchanged.

**Abandoned-edit case:** if the editor creates a collection and then leaves without saving the artwork, an empty unpublished draft collection remains. It appears in `/admin/collections` and can be edited or removed there. That is a visible, self-explanatory leftover rather than a half-attached membership.

## Slug

The control asks for a name only. `parseCollectionInput` derives the slug with a new `slugify` in `src/lib/slug.ts` when the `slug` key is absent. An empty slug *string* is still "Slug is required", so `CollectionForm`'s behaviour is unchanged. A name that cannot produce a slug (`!!!`) is rejected as "Name must contain letters or numbers". A duplicate surfaces to the editor rather than being silently de-duplicated.

## Included fix

A slug collision used to answer **400 with the whole SQL statement and every bound parameter** in the error message. Drizzle wraps a driver failure as `Failed query: <sql> params: <values>` and keeps the driver error as the `cause`, so `mutationError`'s unique-constraint match never saw it. It now walks the cause chain and never reports the wrapper. Duplicates answer 409 `Slug already exists`, as the inline control needs.

## Behaviour and accessibility

- Real `<button type="button">` inside the fieldset; no nested form, no navigation, the API's `redirect` is deliberately ignored.
- Enter in the name field is intercepted, so it creates a collection instead of submitting the artwork.
- The field carries **no** `name` attribute, so it stays out of the artwork's `FormData` payload. Every existing field `name` and `data-*` hook is untouched.
- Real `<label for>`; an `aria-live="polite"` status region reports the outcome; success also moves focus to the new checkbox.
- Failures report inline beside the control, not only in the form's top banner, and the typed name is kept.
- Chrome is reused from `ConsoleShell` — `--seal-text` for the error, a 0.45-alpha paper border on the button for the 3:1 control boundary, and the shell's existing `:focus-visible` ring.
- `Response.redirect()` is not used anywhere in this change.

## Verification

`bun test` 70 pass (was 62), `bun run build` clean.

Exercised against a real local runtime (seeded fixture db served through sqld, dev server, `/admin/artworks/camelia`), typing and pressing Enter with real key events:

- Created "Winter Studies": no navigation, an unsaved title edit survived, checkbox `value=7` inserted and checked, focus landed on it.
  `collections`: `[7, 'Winter Studies', 'winter-studies', published_at NULL]`, and `artworks_to_collections` for collection 7 was **empty** at that point.
- Saved the artwork; `artworks_to_collections` joined:
  ```
  artwork_id  slug     collection_id  name             is_default_for_collection
  10          camelia  3              Botánica         0
  10          camelia  7              Winter Studies   0
  ```
  The pre-existing membership was kept and the new one added.
- Duplicate path: creating "winter studies" again answered `409 {"error":"Slug already exists"}`, shown inline in `--seal-text`, the typed name kept, focus returned to the field, unsaved `year=1999` and `artist=Unsaved artist` intact, no checkbox inserted, top banner still hidden.
- `{"name":"!!!"}` answered `400 {"error":"Name must contain letters or numbers"}`; an empty field is caught client-side without a request.

Not verified: the new-artwork page (`/admin/artworks/new`) was not exercised in the browser, only reasoned about — it renders the same component; screen-reader announcement was checked by DOM and role only, not with an actual screen reader.

CI's `Astro build` and `Build + version-upload preview` checks should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUg79DS5NMAYBzRvuVhtcX
